### PR TITLE
Handle bin files

### DIFF
--- a/app/CustomClasses/SaveConfigsToDiskAndDb.php
+++ b/app/CustomClasses/SaveConfigsToDiskAndDb.php
@@ -72,6 +72,8 @@ class SaveConfigsToDiskAndDb
         $this->model->end_time = $this->devicerecord['end_time']->toDateTimeString();
         $this->model->duration = $duration;
         $this->model->latest_version = 1;
+        $command = Command::where('command', $this->commandName)->first();
+        $this->model->base64 = $command ? $command->base64 : false;
 
         $saved = $this->model->save();
 

--- a/app/CustomClasses/SaveConfigsToDiskAndDb.php
+++ b/app/CustomClasses/SaveConfigsToDiskAndDb.php
@@ -74,6 +74,7 @@ class SaveConfigsToDiskAndDb
         $this->model->latest_version = 1;
         $command = Command::where('command', $this->commandName)->first();
         $this->model->base64 = $command ? $command->base64 : false;
+        $this->model->ext = $command ? $command->ext : "";
 
         $saved = $this->model->save();
 

--- a/app/DataTransferObjects/StoreCommandDTO.php
+++ b/app/DataTransferObjects/StoreCommandDTO.php
@@ -10,10 +10,12 @@ final class StoreCommandDTO extends DtoBase
 {
     public string $command;
     public ?string $description;
+    public ?bool $base64;
 
     public function __construct(array $parameters = [])
     {
         $this->command = $parameters['command'];
         $this->description = $parameters['description'];
+        $this->base64 = isset($parameters['base64']) ? (bool) $parameters['base64'] : null;
     }
 }

--- a/app/DataTransferObjects/StoreCommandDTO.php
+++ b/app/DataTransferObjects/StoreCommandDTO.php
@@ -10,12 +10,14 @@ final class StoreCommandDTO extends DtoBase
 {
     public string $command;
     public ?string $description;
-    public ?bool $base64;
+    public ?bool $base64;   // data is base64 encoded ?
+    public ?string $ext;    // File Extension (to subtitute '.txt' default file extension)
 
     public function __construct(array $parameters = [])
     {
         $this->command = $parameters['command'];
         $this->description = $parameters['description'];
         $this->base64 = isset($parameters['base64']) ? (bool) $parameters['base64'] : null;
+        $this->ext = $parameters['ext'];
     }
 }

--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -115,6 +115,7 @@ class ConfigController extends ApiBaseController
             $result = [
                 'content' => $utf8_string,
                 'config_location' => $config_location,
+                'base64' => (bool) Config::find($id)->base64,
             ];
 
             return $this->successResponse('Success', $result);

--- a/app/Http/Controllers/Api/ConfigController.php
+++ b/app/Http/Controllers/Api/ConfigController.php
@@ -116,6 +116,7 @@ class ConfigController extends ApiBaseController
                 'content' => $utf8_string,
                 'config_location' => $config_location,
                 'base64' => (bool) Config::find($id)->base64,
+                'ext' => Config::find($id)->ext,
             ];
 
             return $this->successResponse('Success', $result);

--- a/app/Http/Requests/StoreCommandRequest.php
+++ b/app/Http/Requests/StoreCommandRequest.php
@@ -50,6 +50,7 @@ class StoreCommandRequest extends FormRequest
             'description' => $this->description,
             'category' => $this->category,
             'base64' => $this->base64,
+            'ext' => $this->ext,
         ]);
     }
 }

--- a/app/Http/Requests/StoreCommandRequest.php
+++ b/app/Http/Requests/StoreCommandRequest.php
@@ -28,6 +28,7 @@ class StoreCommandRequest extends FormRequest
             $rules = [
                 'command' => 'required|min:3|unique:commands|max:255',
                 'categoryArray' => 'required|array|min:1',
+                'base64' => 'nullable|boolean',
             ];
         }
 
@@ -35,6 +36,7 @@ class StoreCommandRequest extends FormRequest
             $rules = [
                 'command' => 'required|min:3|max:255',
                 'categoryArray' => 'required|array|min:1',
+                'base64' => 'nullable|boolean',
             ];
         }
 
@@ -47,6 +49,7 @@ class StoreCommandRequest extends FormRequest
             'command' => $this->command,
             'description' => $this->description,
             'category' => $this->category,
+            'base64' => $this->base64,
         ]);
     }
 }

--- a/database/migrations/2026_03_05_152659_add_base64_and_ext_fields.php
+++ b/database/migrations/2026_03_05_152659_add_base64_and_ext_fields.php
@@ -13,9 +13,11 @@ return new class extends Migration
     {
         Schema::table('commands', function (Blueprint $table) {
             $table->boolean('base64')->default(false);
+            $table->string('ext')->nullable();
         });
         Schema::table('configs', function (Blueprint $table) {
             $table->boolean('base64')->default(false);
+            $table->string('ext')->nullable();
         });
     }
 
@@ -26,9 +28,11 @@ return new class extends Migration
     {
         Schema::table('commands', function (Blueprint $table) {
             $table->dropColumn('base64');
+            $table->dropColumn('ext');
         });
         Schema::table('configs', function (Blueprint $table) {
             $table->dropColumn('base64');
+            $table->dropColumn('ext');
         });
     }
 };

--- a/database/migrations/2026_03_05_152659_add_base64_field.php
+++ b/database/migrations/2026_03_05_152659_add_base64_field.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('commands', function (Blueprint $table) {
+            $table->boolean('base64')->default(false);
+        });
+        Schema::table('configs', function (Blueprint $table) {
+            $table->boolean('base64')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('commands', function (Blueprint $table) {
+            $table->dropColumn('base64');
+        });
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('base64');
+        });
+    }
+};

--- a/resources/js/composables/codeEditorFunctions.js
+++ b/resources/js/composables/codeEditorFunctions.js
@@ -217,7 +217,26 @@ export default function useCodeEditor(monaco) {
 		});
 	}
 
-	function download(filename = null) {
+    function txt_to_bin(txt) {
+	    const data = txt.replace(/\n/g, '').replace(/\r/g, '');
+	    const binary = atob(data);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        const blob = new Blob([bytes], { type: "application/octet-stream" });
+        return blob;
+    }
+
+	function download(filename = null, isBase64 = false) {
+        const base64Val = isBase64?.value ?? isBase64;
+        if (base64Val) {
+            console.log("decode base64 to bin");
+            const bin_blob = txt_to_bin(meditor.getValue());
+            saveAs(bin_blob, filename);
+	        return;
+        }
+
 		isDownloaded.value = true;
 
 		const blob = new Blob([meditor.getValue()], { type: "text/plain;charset=utf-8" });

--- a/resources/js/composables/codeEditorFunctions.js
+++ b/resources/js/composables/codeEditorFunctions.js
@@ -219,7 +219,13 @@ export default function useCodeEditor(monaco) {
 
 	function txt_to_bin(txt) {
 		const data = txt.replace(/\n/g, '').replace(/\r/g, '');
-		const binary = atob(data);
+		let binary;
+		try {
+			binary = atob(data);
+		} catch (e) {
+			alert("Can't decode base64.");
+			return null;
+		}
 		const bytes = new Uint8Array(binary.length);
 		for (let i = 0; i < binary.length; i++) {
 			bytes[i] = binary.charCodeAt(i);
@@ -228,12 +234,16 @@ export default function useCodeEditor(monaco) {
 		return blob;
 	}
 
-	function download(filename = null, isBase64 = false) {
+	function download(filename = null, isBase64 = false, ext = "") {
 		const base64Val = isBase64?.value ?? isBase64;
+		const extVal = ext?.value ?? ext;
 		if (base64Val) {
 			console.log("decode base64 to bin");
 			const bin_blob = txt_to_bin(meditor.getValue());
-			saveAs(bin_blob, filename);
+			if (bin_blob === null) {
+				return;
+			}
+			saveAs(bin_blob, filename.slice(0, -4) + '.' + extVal);
 			return;
 		}
 

--- a/resources/js/composables/codeEditorFunctions.js
+++ b/resources/js/composables/codeEditorFunctions.js
@@ -217,25 +217,25 @@ export default function useCodeEditor(monaco) {
 		});
 	}
 
-    function txt_to_bin(txt) {
-	    const data = txt.replace(/\n/g, '').replace(/\r/g, '');
-	    const binary = atob(data);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) {
-            bytes[i] = binary.charCodeAt(i);
-        }
-        const blob = new Blob([bytes], { type: "application/octet-stream" });
-        return blob;
-    }
+	function txt_to_bin(txt) {
+		const data = txt.replace(/\n/g, '').replace(/\r/g, '');
+		const binary = atob(data);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) {
+			bytes[i] = binary.charCodeAt(i);
+		}
+		const blob = new Blob([bytes], { type: "application/octet-stream" });
+		return blob;
+	}
 
 	function download(filename = null, isBase64 = false) {
-        const base64Val = isBase64?.value ?? isBase64;
-        if (base64Val) {
-            console.log("decode base64 to bin");
-            const bin_blob = txt_to_bin(meditor.getValue());
-            saveAs(bin_blob, filename);
-	        return;
-        }
+		const base64Val = isBase64?.value ?? isBase64;
+		if (base64Val) {
+			console.log("decode base64 to bin");
+			const bin_blob = txt_to_bin(meditor.getValue());
+			saveAs(bin_blob, filename);
+			return;
+		}
 
 		isDownloaded.value = true;
 

--- a/resources/js/pages/Configs/ConfigView/ConfigViewMainPanel.vue
+++ b/resources/js/pages/Configs/ConfigView/ConfigViewMainPanel.vue
@@ -48,6 +48,7 @@ const {
 const {
 	// State
 	config_location,
+    base64,
 
 	// Functions
 	getDefaultEditorCode,
@@ -125,7 +126,7 @@ function initCodeEditor() {
 
 								<RcToolTip :delayDuration="100" :content="'Download Configs'" :side="'bottom'">
 									<template #trigger>
-										<Button variant="ghost" @click="download(config_location)" class="px-2 py-1 rc-btn-shadow">
+										<Button variant="ghost" @click="download(config_location, base64)" class="px-2 py-1 rc-btn-shadow">
 											<RcIcon name="copy-download-transition" :isActive="isDownloaded" :size="16" />
 										</Button>
 									</template>

--- a/resources/js/pages/Configs/ConfigView/ConfigViewMainPanel.vue
+++ b/resources/js/pages/Configs/ConfigView/ConfigViewMainPanel.vue
@@ -48,7 +48,7 @@ const {
 const {
 	// State
 	config_location,
-    base64,
+	base64,
 
 	// Functions
 	getDefaultEditorCode,

--- a/resources/js/pages/Configs/ConfigView/ConfigViewMainPanel.vue
+++ b/resources/js/pages/Configs/ConfigView/ConfigViewMainPanel.vue
@@ -49,6 +49,7 @@ const {
 	// State
 	config_location,
 	base64,
+	ext,
 
 	// Functions
 	getDefaultEditorCode,
@@ -126,7 +127,7 @@ function initCodeEditor() {
 
 								<RcToolTip :delayDuration="100" :content="'Download Configs'" :side="'bottom'">
 									<template #trigger>
-										<Button variant="ghost" @click="download(config_location, base64)" class="px-2 py-1 rc-btn-shadow">
+										<Button variant="ghost" @click="download(config_location, base64, ext)" class="px-2 py-1 rc-btn-shadow">
 											<RcIcon name="copy-download-transition" :isActive="isDownloaded" :size="16" />
 										</Button>
 									</template>

--- a/resources/js/pages/Configs/ConfigView/useConfigViewMainPanel.js
+++ b/resources/js/pages/Configs/ConfigView/useConfigViewMainPanel.js
@@ -8,6 +8,7 @@ export default function useConfigViewMainPanel(props) {
 	const errors = ref([]);
 	const config_location = ref("");
 	const base64 = ref(false);
+	const ext = ref("");
 	const extension = ref("");
 	const sheetStore = useSheetStore();
 	const { openSheet } = sheetStore;
@@ -32,6 +33,7 @@ export default function useConfigViewMainPanel(props) {
 
 			config_location.value = location || "No file location provided";
 			base64.value = data?.data?.base64 ?? false;
+			ext.value = data?.data?.ext ?? "";
 			meditor.getModel().setValue(content || "No content available.");
 
 			if (location) {
@@ -102,6 +104,7 @@ export default function useConfigViewMainPanel(props) {
 		// State
 		config_location,
 		base64,
+		ext,
 		errors,
 
 		// Functions

--- a/resources/js/pages/Configs/ConfigView/useConfigViewMainPanel.js
+++ b/resources/js/pages/Configs/ConfigView/useConfigViewMainPanel.js
@@ -7,6 +7,7 @@ export default function useConfigViewMainPanel(props) {
 	const { toastError } = useToaster();
 	const errors = ref([]);
 	const config_location = ref("");
+	const base64 = ref(false);
 	const extension = ref("");
 	const sheetStore = useSheetStore();
 	const { openSheet } = sheetStore;
@@ -30,6 +31,7 @@ export default function useConfigViewMainPanel(props) {
 			const location = data?.data?.config_location ?? null;
 
 			config_location.value = location || "No file location provided";
+            base64.value = data?.data?.base64 ?? false;
 			meditor.getModel().setValue(content || "No content available.");
 
 			if (location) {
@@ -99,6 +101,7 @@ export default function useConfigViewMainPanel(props) {
 	return {
 		// State
 		config_location,
+        base64,
 		errors,
 
 		// Functions

--- a/resources/js/pages/Configs/ConfigView/useConfigViewMainPanel.js
+++ b/resources/js/pages/Configs/ConfigView/useConfigViewMainPanel.js
@@ -31,7 +31,7 @@ export default function useConfigViewMainPanel(props) {
 			const location = data?.data?.config_location ?? null;
 
 			config_location.value = location || "No file location provided";
-            base64.value = data?.data?.base64 ?? false;
+			base64.value = data?.data?.base64 ?? false;
 			meditor.getModel().setValue(content || "No content available.");
 
 			if (location) {
@@ -101,7 +101,7 @@ export default function useConfigViewMainPanel(props) {
 	return {
 		// State
 		config_location,
-        base64,
+		base64,
 		errors,
 
 		// Functions

--- a/resources/js/pages/Inventory/Commands/CommandAddEditDialog.vue
+++ b/resources/js/pages/Inventory/Commands/CommandAddEditDialog.vue
@@ -20,6 +20,7 @@ const model = ref({
 	description: "",
 	category: [],
 	base64: false,
+    ext: "",
 });
 
 const props = defineProps({
@@ -125,6 +126,15 @@ function saveDialog() {
 					   <Skeleton class="h-6 w-6" />
 				   </div>
 				   <Checkbox v-else id="base64" v-model:checked="model.base64" />
+				</div>
+
+				<!-- File Extension Field -->
+				<div class="grid items-center grid-cols-4 gap-2">
+					<Label for="ext" class="text-right">File Extension</Label>
+					<div v-if="isLoading" class="col-span-3">
+						<Skeleton class="h-6 w-full" />
+					</div>
+					<Input v-else v-model="model.ext" id="ext" class="col-span-3" />
 				</div>
 
 				<!-- Command Group Field -->

--- a/resources/js/pages/Inventory/Commands/CommandAddEditDialog.vue
+++ b/resources/js/pages/Inventory/Commands/CommandAddEditDialog.vue
@@ -19,6 +19,7 @@ const model = ref({
 	command: "",
 	description: "",
 	category: [],
+	base64: false,
 });
 
 const props = defineProps({
@@ -56,10 +57,14 @@ onUnmounted(() => {
 });
 
 function saveDialog() {
+    const payload = {
+        ...model.value,
+        base64: model.value.base64 ? 1 : 0,
+    };
 	const id = props.editId > 0 ? `/${props.editId}` : "";
 	const method = props.editId > 0 ? "patch" : "post";
 
-	axios[method]("/api/commands" + id, model.value)
+	axios[method]("/api/commands" + id, payload)
 		.then((response) => {
 			emit("save", response.data);
 			toastSuccess("Command saved", "The command has been saved successfully.");
@@ -111,6 +116,15 @@ function saveDialog() {
 						<Skeleton class="h-6 w-full" />
 					</div>
 					<Input v-else v-model="model.description" id="description" class="col-span-3" />
+				</div>
+
+				<!-- base64 Field -->
+				<div class="grid items-center grid-cols-4 gap-2">
+				   <Label for="base64" class="text-right">base64</Label>
+				   <div v-if="isLoading" class="col-span-3">
+					   <Skeleton class="h-6 w-6" />
+				   </div>
+				   <Checkbox v-else id="base64" v-model:checked="model.base64" />
 				</div>
 
 				<!-- Command Group Field -->

--- a/tests/Fasttests/ControllersTests/Api/CommandsControllerTest.php
+++ b/tests/Fasttests/ControllersTests/Api/CommandsControllerTest.php
@@ -111,6 +111,7 @@ class CommandsControllerTest extends TestCase
         $response = $this->json('post', '/api/commands', [
             'command' => $command->command,
             'description' => $command->description,
+            'base64' => true,
             'categoryArray' => $categories->pluck('id')->toArray(),
         ]);
 
@@ -125,6 +126,7 @@ class CommandsControllerTest extends TestCase
         $this->assertDatabaseHas('commands', [
             'command' => $command->command,
             'description' => $command->description,
+            'base64' => true,
         ]);
     }
 
@@ -145,6 +147,7 @@ class CommandsControllerTest extends TestCase
         $response = $this->json('post', '/api/commands', [
             'command' => $command->command,
             'description' => $command->description,
+            'base64' => true,
             'categoryArray' => $categories->pluck('id')->toArray(),
         ]);
         $response->assertStatus(200);
@@ -158,6 +161,7 @@ class CommandsControllerTest extends TestCase
         $this->assertDatabaseHas('commands', [
             'command' => $command->command,
             'description' => $command->description,
+            'base64' => true,
         ]);
 
         $categories2 = Category::factory(3)->create();
@@ -165,6 +169,7 @@ class CommandsControllerTest extends TestCase
         $response = $this->json('PATCH', '/api/commands/' . $insertedComand->id, [
             'command' => 'new command',
             'description' => 'new description',
+            'base64' => true,
             'categoryArray' => $categories2->pluck('id')->toArray(),
         ]);
         $response->assertStatus(200);
@@ -172,6 +177,7 @@ class CommandsControllerTest extends TestCase
         $response = $this->json('PATCH', '/api/commands/' . $insertedComand->id, [
             'command' => 'a new command name',
             'description' => 'a new description name',
+            'base64' => true,
             'categoryArray' => $categories2->pluck('id')->toArray(),
         ]);
 
@@ -187,6 +193,21 @@ class CommandsControllerTest extends TestCase
             'id' => $insertedComand->id,
             'command' => 'a new command name',
             'description' => 'a new description name',
+            'base64' => true,
+        ]);
+
+        $response = $this->json('PATCH', '/api/commands/' . $insertedComand->id, [
+            'command' => 'a new command name',
+            'description' => 'a new description name',
+            'base64' => false,
+            'categoryArray' => $categories2->pluck('id')->toArray(),
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('commands', [
+            'id' => $insertedComand->id,
+            'base64' => false,
         ]);
     }
 

--- a/tests/Fasttests/ControllersTests/Api/ConfigControllerTest.php
+++ b/tests/Fasttests/ControllersTests/Api/ConfigControllerTest.php
@@ -175,9 +175,19 @@ class ConfigControllerTest extends TestCase
         $response->assertStatus(200);
     }
 
-    public function test_show_single_config()
+    public function test_config_has_default_values_for_base64_and_ext()
     {
         $config = Config::factory()->create();
+        $this->assertDatabaseHas('configs', [
+            'id' => $config->id,
+            'base64' => false,
+            'ext' => null,
+        ]);
+    }
+
+    public function test_show_single_config()
+    {
+        $config = Config::factory()->create(['base64' => true, 'ext' => 'tar.gz']);
         $response = $this->get('/api/configs/' . $config->id);
         // dd($response);
         $response->assertStatus(200);
@@ -186,7 +196,9 @@ class ConfigControllerTest extends TestCase
             'id' => $config->id,
             'device_name' => $config->device_name,
             'device_category' => $config->device_category,
-        ]);
+            'base64' => true,
+            'ext' => 'tar.gz',
+            ]);
     }
 
     public function test_get_single_config_file_contents_and_response_time_for_large_file()
@@ -259,6 +271,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:05:48',
                 'updated_at' => '2022-01-15 17:05:48',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -276,6 +290,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:05:48',
                 'updated_at' => '2022-01-15 17:05:48',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -293,6 +309,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:05:48',
                 'updated_at' => '2022-01-15 17:05:48',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -310,6 +328,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:07:09',
                 'updated_at' => '2022-01-15 17:07:09',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -327,6 +347,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:07:09',
                 'updated_at' => '2022-01-15 17:07:09',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -344,6 +366,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:07:09',
                 'updated_at' => '2022-01-15 17:07:09',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -361,6 +385,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:07:40',
                 'updated_at' => '2022-01-15 17:07:40',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -378,6 +404,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:07:40',
                 'updated_at' => '2022-01-15 17:07:40',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -395,6 +423,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:17:27',
                 'updated_at' => '2022-01-15 17:17:27',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -412,6 +442,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:17:27',
                 'updated_at' => '2022-01-15 17:17:27',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -429,6 +461,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:17:34',
                 'updated_at' => '2022-01-15 17:17:34',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -446,6 +480,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:17:34',
                 'updated_at' => '2022-01-15 17:17:34',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1002,
@@ -463,6 +499,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-15 17:17:34',
                 'updated_at' => '2022-01-15 17:17:34',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -480,6 +518,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:08:23',
                 'updated_at' => '2022-01-17 17:08:23',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -497,6 +537,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:08:23',
                 'updated_at' => '2022-01-17 17:08:23',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -514,6 +556,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:08:23',
                 'updated_at' => '2022-01-17 17:08:23',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -531,6 +575,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:09:54',
                 'updated_at' => '2022-01-17 17:09:54',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -548,6 +594,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:09:54',
                 'updated_at' => '2022-01-17 17:09:54',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -565,6 +613,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:09:54',
                 'updated_at' => '2022-01-17 17:09:54',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -582,6 +632,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -599,6 +651,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -616,6 +670,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -633,6 +689,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -650,6 +708,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1001,
@@ -667,6 +727,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1002,
@@ -684,6 +746,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1003,
@@ -701,6 +765,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
             [
                 'device_id' => 1004,
@@ -718,6 +784,8 @@ class ConfigControllerTest extends TestCase
                 'duration' => 1,
                 'created_at' => '2022-01-17 17:10:03',
                 'updated_at' => '2022-01-17 17:10:03',
+                'base64' => true,
+                'ext' => 'tar.gz'
             ],
         ];
         Config::insert($configs);


### PR DESCRIPTION
It will be great to manage binary files, not only TXT files in rConfig. Hence, one can get tar.gz, zip or any type of file. A simple way to do this is to handle base64 encoded data.

This PR add 2 fields to `commands` : 
- base64 as boolean
- File extension as string (exemple 'tar.gz', 'zip'...)

When the user want to download the file, if base64 value is true then the base64 data is decoded and the file extension is added to filename. The user get the original file.