### PR TITLE
Make health ping checks configurable for offline and air-gapped deployments

### DIFF
--- a/app/Providers/HealthCheckProvider.php
+++ b/app/Providers/HealthCheckProvider.php
@@ -32,14 +32,13 @@ class HealthCheckProvider extends ServiceProvider
      */
     public function boot()
     {
-        Health::checks([
+        $checks = [
             DatabaseCheck::new(),
             CacheCheck::new(),
             CpuLoadCheck::new()
                 ->failWhenLoadIsHigherInTheLast5Minutes(2.0)
                 ->failWhenLoadIsHigherInTheLast15Minutes(1.5),
             HorizonCheck::new(),
-            PingCheck::new()->failureMessage('Pinging rconfig.com failed')->url('https://www.rconfig.com')->timeout(5),
             RedisCheck::new(),
             ScheduleCheck::new()->heartbeatMaxAgeInMinutes(10),
             RcDiskSpaceCheck::new()
@@ -47,6 +46,21 @@ class HealthCheckProvider extends ServiceProvider
                 ->filesystemName(storage_path())
                 ->warnWhenUsedSpaceIsAbovePercentage(70)
                 ->failWhenUsedSpaceIsAbovePercentage(90),
-        ]);
+        ];
+
+        $pingEnabled = (bool) config('health.ping.enabled', true);
+        $offlineMode = (bool) config('health.ping.offline_mode', false);
+        $airGapped = (bool) config('health.ping.air_gapped', false);
+        $pingTarget = (string) config('health.ping.target', 'https://www.rconfig.com');
+        $pingTimeout = (int) config('health.ping.timeout', 5);
+
+        if ($pingEnabled && ! $offlineMode && ! $airGapped && $pingTarget !== '') {
+            $checks[] = PingCheck::new()
+                ->failureMessage("Pinging {$pingTarget} failed")
+                ->url($pingTarget)
+                ->timeout($pingTimeout);
+        }
+
+        Health::checks($checks);
     }
 }

--- a/config/health.php
+++ b/config/health.php
@@ -111,4 +111,21 @@ return [
      * - dark: dark mode
      */
     'theme' => 'light',
+
+    /*
+     * Configure the connectivity ping check.
+     *
+     * - Set `HEALTHCHECK_PING_ENABLED=false` to disable the check entirely.
+     * - Set `HEALTHCHECK_OFFLINE_MODE=true` or `HEALTHCHECK_AIR_GAPPED=true`
+     *   to automatically skip external ping checks.
+     * - Set `HEALTHCHECK_PING_TARGET` to an internal endpoint/host such as
+     *   `http://127.0.0.1`, `http://localhost`, or your gateway address.
+     */
+    'ping' => [
+        'enabled' => env('HEALTHCHECK_PING_ENABLED', true),
+        'offline_mode' => env('HEALTHCHECK_OFFLINE_MODE', false),
+        'air_gapped' => env('HEALTHCHECK_AIR_GAPPED', false),
+        'target' => env('HEALTHCHECK_PING_TARGET', 'https://www.rconfig.com'),
+        'timeout' => (int) env('HEALTHCHECK_PING_TIMEOUT', 5),
+    ],
 ];

--- a/tests/Unit/Providers/HealthCheckProviderTest.php
+++ b/tests/Unit/Providers/HealthCheckProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit\Providers;
+
+use App\Providers\HealthCheckProvider;
+use Spatie\Health\Checks\Checks\PingCheck;
+use Spatie\Health\Facades\Health;
+use Tests\TestCase;
+
+class HealthCheckProviderTest extends TestCase
+{
+    public function test_it_registers_ping_check_when_enabled_and_online()
+    {
+        config()->set('health.ping.enabled', true);
+        config()->set('health.ping.offline_mode', false);
+        config()->set('health.ping.air_gapped', false);
+        config()->set('health.ping.target', 'https://www.rconfig.com');
+
+        Health::shouldReceive('checks')
+            ->once()
+            ->withArgs(function (array $checks) {
+                return $this->containsCheck($checks, PingCheck::class);
+            });
+
+        (new HealthCheckProvider($this->app))->boot();
+    }
+
+    public function test_it_skips_ping_check_when_ping_is_disabled()
+    {
+        config()->set('health.ping.enabled', false);
+        config()->set('health.ping.offline_mode', false);
+        config()->set('health.ping.air_gapped', false);
+        config()->set('health.ping.target', 'https://www.rconfig.com');
+
+        Health::shouldReceive('checks')
+            ->once()
+            ->withArgs(function (array $checks) {
+                return ! $this->containsCheck($checks, PingCheck::class);
+            });
+
+        (new HealthCheckProvider($this->app))->boot();
+    }
+
+    public function test_it_skips_ping_check_in_offline_mode()
+    {
+        config()->set('health.ping.enabled', true);
+        config()->set('health.ping.offline_mode', true);
+        config()->set('health.ping.air_gapped', false);
+        config()->set('health.ping.target', 'https://www.rconfig.com');
+
+        Health::shouldReceive('checks')
+            ->once()
+            ->withArgs(function (array $checks) {
+                return ! $this->containsCheck($checks, PingCheck::class);
+            });
+
+        (new HealthCheckProvider($this->app))->boot();
+    }
+
+    public function test_it_skips_ping_check_in_air_gapped_mode()
+    {
+        config()->set('health.ping.enabled', true);
+        config()->set('health.ping.offline_mode', false);
+        config()->set('health.ping.air_gapped', true);
+        config()->set('health.ping.target', 'https://www.rconfig.com');
+
+        Health::shouldReceive('checks')
+            ->once()
+            ->withArgs(function (array $checks) {
+                return ! $this->containsCheck($checks, PingCheck::class);
+            });
+
+        (new HealthCheckProvider($this->app))->boot();
+    }
+
+    public function test_it_registers_ping_check_for_internal_target()
+    {
+        config()->set('health.ping.enabled', true);
+        config()->set('health.ping.offline_mode', false);
+        config()->set('health.ping.air_gapped', false);
+        config()->set('health.ping.target', 'http://127.0.0.1');
+
+        Health::shouldReceive('checks')
+            ->once()
+            ->withArgs(function (array $checks) {
+                return $this->containsCheck($checks, PingCheck::class);
+            });
+
+        (new HealthCheckProvider($this->app))->boot();
+    }
+
+    private function containsCheck(array $checks, string $className): bool
+    {
+        foreach ($checks as $check) {
+            if ($check instanceof $className) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
PR Summary:
This PR fixes false-positive health check failures on isolated networks by making the connectivity ping check configurable and skippable.

What changed:

Added health ping configuration options in [health.php:115](vscode-file://vscode-app/c:/Users/StephenStack-rConfig/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
HEALTHCHECK_PING_ENABLED
HEALTHCHECK_OFFLINE_MODE
HEALTHCHECK_AIR_GAPPED
HEALTHCHECK_PING_TARGET
HEALTHCHECK_PING_TIMEOUT
Updated health check registration logic in [HealthCheckProvider.php:33](vscode-file://vscode-app/c:/Users/StephenStack-rConfig/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
Removed hardcoded external ping behavior
Registers ping check only when enabled and not offline/air-gapped
Supports custom internal ping targets
Keeps existing default target for connected environments
Documented new environment options in [.env.example:82](vscode-file://vscode-app/c:/Users/StephenStack-rConfig/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Added and documented settings guidance in 00_settings.mdx:

Purpose of each setting
Behavior summary
Example configurations for disabled, air-gapped, and internal-only modes
Added unit tests in [HealthCheckProviderTest.php:1](vscode-file://vscode-app/c:/Users/StephenStack-rConfig/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) covering:
Ping included when enabled and online
Ping excluded when disabled
Ping excluded in offline mode
Ping excluded in air-gapped mode
Ping included for internal targets
Why this matters:

Prevents misleading health failures in offline, internal-only, and firewalled deployments
Gives administrators explicit control over connectivity checks
Improves health check signal quality for monitoring and operations
Validation:

Unit tests passed:
vendor/bin/phpunit --filter HealthCheckProviderTest --testsuite Unit