### PR TITLE
fix: enable Sanctum SPA middleware broken by Passport removal in #280

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:1000,1',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],


### PR DESCRIPTION
## Summary

Fixes #281

PR #280 removed `Laravel\Passport\Http\Middleware\CreateFreshApiToken` from the `web` middleware group as part of the Passport → Sanctum migration. That middleware was implicitly enabling SPA authentication by issuing API tokens on every web request.

After its removal, `EnsureFrontendRequestsAreStateful` became the only way for the SPA to authenticate API calls via session cookies — but this middleware has been commented out since the initial commit (March 2023), causing all dashboard API calls to return 401 Unauthorized.

## Changes

- **`app/Http/Kernel.php`**: Uncomment `\Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class` in the `api` middleware group

## Test plan

- [ ] Log in to the application in a browser
- [ ] Verify dashboard loads without 401 errors in the browser console
- [ ] Verify API calls (`/api/user/get-external-links`, `/api/healthLatest`, `/api/sysinfo`, `/api/latestdevices`) return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)