### PR TITLE
fix: guard ide-helper:generate so composer install --no-dev succeeds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rconfig/rconfig",
     "type": "project",
     "description": "rConfig V8 Core",
-    "version": "8.1.0",
+    "version": "8.1.1",
     "keywords": [
         "framework",
         "laravel"
@@ -71,7 +71,7 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
-            "@php artisan ide-helper:generate --ansi"
+            "@php -r \"file_exists('vendor/barryvdh/laravel-ide-helper') && passthru('php artisan ide-helper:generate --ansi');\""
         ],
         "post-update-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postUpdate",

--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
     'name' => env('APP_NAME', 'rConfig v8 Core'),
     // run test before updating the version
-    'version' => '8.1.0',
+    'version' => '8.1.1',
     'force_https' => env('APP_FORCE_HTTPS', false),
 
     /*


### PR DESCRIPTION
## Problem

Customer report ([issue](https://github.com/rconfig/rconfig/issues)): running `composer install --no-dev` fails with:

```
ERROR There are no commands defined in the "ide-helper" namespace.
```

The `post-autoload-dump` script ran `php artisan ide-helper:generate` unconditionally. That command comes from `barryvdh/laravel-ide-helper`, which is a `require-dev` package, so under `--no-dev` the command does not exist and Composer aborts. It only affects production-style installs, which is why dev installs never hit it.

## Fix

Guard the call so it only runs when the package is actually present:

```json
"@php -r \"file_exists('vendor/barryvdh/laravel-ide-helper') && passthru('php artisan ide-helper:generate --ansi');\""
```

- `composer install` (dev) → package present → IDE helper still regenerates as before.
- `composer install --no-dev` → package absent → no-op, install completes cleanly.

Runs through `@php -r` so it stays cross-platform (no shell `|| true`).

Version bumped `8.1.0` → `8.1.1`.

## Customer workaround (pre-release)

```bash
composer install --no-dev --no-scripts
php artisan package:discover --ansi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)