### PR TITLE
fix: send email on device connection/backup failure (RCO-968)

### DIFF
--- a/app/Jobs/DeviceDownloadJob.php
+++ b/app/Jobs/DeviceDownloadJob.php
@@ -5,9 +5,13 @@ namespace App\Jobs;
 use App\CustomClasses\DeviceRecordPrepare;
 use App\CustomClasses\SaveConfigsToDiskAndDb;
 use App\CustomClasses\SetDeviceStatus;
+use App\Enums\NotificationChannel;
+use App\Enums\NotificationType;
 use App\Http\Controllers\Connections\MainConnectionManager;
-use App\Models\User;
 use App\Notifications\DBDeviceConnectionFailureNotification;
+use App\Notifications\DBNotification;
+use App\Notifications\MailDeviceConnectionFailureNotification;
+use App\Traits\NotificationDispatcher;
 use Carbon\Carbon;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -15,12 +19,11 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Redis;
 
 class DeviceDownloadJob extends Command
 {
-    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Batchable, Dispatchable, InteractsWithQueue, NotificationDispatcher, Queueable, SerializesModels;
 
     protected $output;
     protected $eventtype;
@@ -63,7 +66,7 @@ class DeviceDownloadJob extends Command
         if ($configsArray === false || isset($configsArray['failure'])) {
             $this->devicerecord['end_time'] = Carbon::now();
             $logmsg = 'No config data returned for ' . ($this->devicerecord['device_name'] . ' - ID:' . $this->devicerecord['id'] . '. Check your logs for more information');
-            Notification::send(User::all(), new DBDeviceConnectionFailureNotification($logmsg, $this->devicerecord['id']));
+            $this->sendDeviceConnectionFailureNotifications($logmsg);
 
             $configSaveResult = (new SaveConfigsToDiskAndDb('device_download', 'Failed config download', 0, $this->devicerecord, $this->report_id))->saveConfigs();
 
@@ -95,5 +98,28 @@ class DeviceDownloadJob extends Command
         Redis::set('download-now-' . $this->devicerecord['id'], 'false');
 
         return $this->output;
+    }
+
+    /**
+     * Dispatch device connection failure notifications, honouring each user's
+     * per-channel preferences. Sends an in-app (DB) alert and an email alert
+     * only to the users who have opted in to each channel.
+     */
+    protected function sendDeviceConnectionFailureNotifications(string $logmsg): void
+    {
+        $deviceId = $this->devicerecord['id'];
+
+        $this->sendToSingleChannel(
+            NotificationType::CONNECTION_DEVICE_FAILURE,
+            NotificationChannel::DB,
+            new DBDeviceConnectionFailureNotification($logmsg, $deviceId)
+        );
+
+        $this->sendNotificationWithErrorFallback(
+            NotificationType::CONNECTION_DEVICE_FAILURE,
+            new MailDeviceConnectionFailureNotification($logmsg, $deviceId),
+            [NotificationChannel::MAIL],
+            new DBNotification('Notification error', 'Could not send device connection failure email notification', 'system', 'error', 'pficon-error-circle-o')
+        );
     }
 }

--- a/app/Notifications/MailDeviceConnectionFailureNotification.php
+++ b/app/Notifications/MailDeviceConnectionFailureNotification.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\HtmlString;
+
+class MailDeviceConnectionFailureNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(protected string $msg, protected int|string $deviceid) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(mixed $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(mixed $notifiable): ?MailMessage
+    {
+        try {
+            return (new MailMessage)
+                ->error()
+                ->subject('Device connection failure notification')
+                ->greeting('Device connection failure!')
+                ->line(new HtmlString('rConfig failed to connect to or download a config for Device ID:<strong>' . $this->deviceid . '</strong>.'))
+                ->line($this->msg)
+                ->action('View device', url('/devices/' . $this->deviceid))
+                ->line('Check the device logs for more information.');
+        } catch (\Exception $exception) {
+            activityLogIt(__CLASS__, __FUNCTION__, 'error', $exception->getMessage(), 'connection');
+
+            return null;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(mixed $notifiable): array
+    {
+        return [];
+    }
+}

--- a/tests/Fasttests/Jobs/DeviceDownloadJobNotificationTest.php
+++ b/tests/Fasttests/Jobs/DeviceDownloadJobNotificationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Fasttests\Jobs;
+
+use App\Enums\NotificationChannel;
+use App\Enums\NotificationType;
+use App\Jobs\DeviceDownloadJob;
+use App\Models\User;
+use App\Notifications\DBDeviceConnectionFailureNotification;
+use App\Notifications\MailDeviceConnectionFailureNotification;
+use Illuminate\Support\Facades\Notification;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class DeviceDownloadJobNotificationTest extends TestCase
+{
+    /**
+     * Invoke the job's protected failure-notification dispatch directly so we
+     * can assert routing without needing a live device connection.
+     */
+    private function dispatchFailureNotifications(): void
+    {
+        $job = new DeviceDownloadJob(['id' => 999, 'device_name' => 'TestDevice'], 'device', false);
+
+        $method = new ReflectionMethod($job, 'sendDeviceConnectionFailureNotifications');
+        $method->setAccessible(true);
+        $method->invoke($job, 'No config data returned for TestDevice');
+    }
+
+    public function test_device_failure_sends_both_db_and_mail_to_user_opted_in_to_both(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['get_notifications' => true]);
+        $user->setNotificationPreference(NotificationType::CONNECTION_DEVICE_FAILURE, NotificationChannel::DB, true);
+        $user->setNotificationPreference(NotificationType::CONNECTION_DEVICE_FAILURE, NotificationChannel::MAIL, true);
+
+        $this->dispatchFailureNotifications();
+
+        Notification::assertSentTo($user, DBDeviceConnectionFailureNotification::class);
+        Notification::assertSentTo($user, MailDeviceConnectionFailureNotification::class);
+    }
+
+    public function test_device_failure_respects_per_channel_preferences(): void
+    {
+        Notification::fake();
+
+        $dbOnly = User::factory()->create(['get_notifications' => true]);
+        $dbOnly->setNotificationPreference(NotificationType::CONNECTION_DEVICE_FAILURE, NotificationChannel::DB, true);
+        $dbOnly->setNotificationPreference(NotificationType::CONNECTION_DEVICE_FAILURE, NotificationChannel::MAIL, false);
+
+        $this->dispatchFailureNotifications();
+
+        Notification::assertSentTo($dbOnly, DBDeviceConnectionFailureNotification::class);
+        Notification::assertNotSentTo($dbOnly, MailDeviceConnectionFailureNotification::class);
+    }
+
+    public function test_device_failure_skips_users_who_opted_out_of_all_notifications(): void
+    {
+        Notification::fake();
+
+        $optedOut = User::factory()->create(['get_notifications' => false]);
+        $optedOut->setNotificationPreference(NotificationType::CONNECTION_DEVICE_FAILURE, NotificationChannel::DB, true);
+        $optedOut->setNotificationPreference(NotificationType::CONNECTION_DEVICE_FAILURE, NotificationChannel::MAIL, true);
+
+        $this->dispatchFailureNotifications();
+
+        Notification::assertNotSentTo($optedOut, DBDeviceConnectionFailureNotification::class);
+        Notification::assertNotSentTo($optedOut, MailDeviceConnectionFailureNotification::class);
+    }
+}


### PR DESCRIPTION
Fixes #283
Linear: RCO-968

## Problem

Reported by a customer in #283: when a device fails to connect / a backup download fails, **no email alert is sent**, even though email is configured (test emails work), the user enabled the "Device Connection Failure" notification, and tasks have notifications enabled. Only an in-app (DB) notification was created.

## Root cause

Two compounding problems:

1. **No mail-capable notification existed for device failure.** `DBDeviceConnectionFailureNotification` declares `via()` → `['database']` only, with no `toMail()`, and there was no `Mail` counterpart. So the `mail` channel was a silent no-op regardless of preference.
2. **The scheduled-task path bypassed the preference system.** `DeviceDownloadJob::handle()` sent via raw `Notification::send(User::all(), …)`, ignoring `get_notifications` and per-user preferences (and blasting every user).

`NotificationType::CONNECTION_DEVICE_FAILURE` already defaults to `['db' => true, 'mail' => true]`, so the product intends to email on failure; the mail side was just never finished.

## Changes

- **Add** `MailDeviceConnectionFailureNotification` (`via()` → `['mail']`, with `toMail()`).
- **Rework** `DeviceDownloadJob` to `use NotificationDispatcher` and dispatch the DB + Mail notifications per channel (mirroring `DownloadConfigNowJob`), so `get_notifications` and per-user/per-channel preferences are honoured and email is actually delivered.
- **Tests**: both-channel delivery for an opted-in user, per-channel preference routing, and opted-out users skipped.

## Validation against Pro (rconfig8)

The same DB-only gap exists in Pro, but Pro already routes failure dispatch through the `NotificationDispatcher` (respecting preferences) — Core's raw all-users blast was a step behind. This PR brings Core in line with Pro's dispatch and additionally completes the mail path, so it is a candidate to port back to `rconfig8`.

## Verification

- New tests: 3 passed
- Pint: clean
- PHPStan (level 0): no errors
- Full suite: **494 passed, 2 skipped, 0 failed**

## Follow-ups (tracked separately)

- Cosmetic UI count mismatch ("24 available" vs ~16 rendered) in the Vue notification preferences component.
- Port the completed mail path back to Pro (`rconfig8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)