### PR TITLE
chore: bump version to 8.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rconfig/rconfig",
     "type": "project",
     "description": "rConfig V8 Core",
-    "version": "8.1.1",
+    "version": "8.1.2",
     "keywords": [
         "framework",
         "laravel"

--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
     'name' => env('APP_NAME', 'rConfig v8 Core'),
     // run test before updating the version
-    'version' => '8.1.1',
+    'version' => '8.1.2',
     'force_https' => env('APP_FORCE_HTTPS', false),
 
     /*


### PR DESCRIPTION
Version bump to 8.1.2 for the RCO-968 device-failure email notification fix (#301), which merged just before this commit landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)