### PR TITLE
fix: template Reformat Code produces unclosed quotes (RCO-1024)

### DIFF
--- a/app/Services/Templates/TemplateReformatter.php
+++ b/app/Services/Templates/TemplateReformatter.php
@@ -159,7 +159,7 @@ class TemplateReformatter
             // Parse key-value pairs
             if ($currentSection && preg_match('/^([a-zA-Z][a-zA-Z0-9]*)\s*:\s*(.*)$/', $trimmed, $matches)) {
                 $key = $matches[1];
-                $value = $matches[2];
+                $value = $this->stripInlineComment($matches[2]);
 
                 // Handle array values like [240, 2048]
                 if (preg_match('/^\[(.*)\]$/', $value, $arrayMatches)) {
@@ -213,6 +213,36 @@ class TemplateReformatter
         }
 
         return implode("\n", $output);
+    }
+
+    /**
+     * Strips a trailing inline comment from a raw value while preserving any
+     * '#' that appears inside a quoted string.
+     *
+     * @param  string  $value  The raw value portion captured after the key
+     * @return string The value with any inline comment removed
+     */
+    private function stripInlineComment(string $value): string
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $quote = $value[0];
+
+        if ($quote === '"' || $quote === '\'') {
+            $closingPos = strpos($value, $quote, 1);
+
+            if ($closingPos !== false) {
+                // Keep the quoted segment and drop anything after the closing quote
+                return substr($value, 0, $closingPos + 1);
+            }
+        }
+
+        // Unquoted value: an inline comment is whitespace followed by '#'
+        return trim(preg_replace('/\s+#.*$/s', '', $value));
     }
 
     private function formatValue($value): string

--- a/tests/Fasttests/ServiceTests/Templates/TemplateReformatterTest.php
+++ b/tests/Fasttests/ServiceTests/Templates/TemplateReformatterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Fasttests\ServiceTests\Templates;
+
+use App\Services\Templates\TemplateReformatter;
+use Tests\TestCase;
+
+class TemplateReformatterTest extends TestCase
+{
+    protected string $oldFormatPath;
+    protected string $newFormatPath;
+    protected string $inlineCommentsPath;
+    protected TemplateReformatter $reformatter;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->oldFormatPath = base_path('tests/storage/templates/oldformat.yml');
+        $this->newFormatPath = base_path('tests/storage/templates/newformat.yml');
+        $this->inlineCommentsPath = base_path('tests/storage/templates/inlinecomments.yml');
+
+        $this->reformatter = new TemplateReformatter;
+    }
+
+    public function test_can_instantiate_template_reformatter(): void
+    {
+        $this->assertInstanceOf(TemplateReformatter::class, $this->reformatter);
+    }
+
+    public function test_detects_already_new_format_template(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Template file is already in the new format: ' . $this->newFormatPath);
+
+        $this->reformatter->reformatTemplateFile($this->newFormatPath);
+    }
+
+    public function test_can_determine_template_format_correctly(): void
+    {
+        $this->assertFalse($this->reformatter->isNewFormat($this->oldFormatPath));
+        $this->assertTrue($this->reformatter->isNewFormat($this->newFormatPath));
+    }
+
+    public function test_can_convert_old_format_to_new_format(): void
+    {
+        $result = $this->reformatter->reformatTemplateFile($this->oldFormatPath);
+
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    public function test_converted_template_has_correct_structure(): void
+    {
+        $result = $this->reformatter->reformatTemplateFile($this->oldFormatPath);
+
+        $this->assertStringContainsString('name: "SSH Private Key Template"', $result);
+        $this->assertStringContainsString('# Unique name for this template', $result);
+        $this->assertStringContainsString('# Port number for connection', $result);
+        $this->assertStringContainsString('exitCmd: "quit"', $result);
+        $this->assertStringContainsString('setTerminalDimensions: [260, 100000]', $result);
+    }
+
+    public function test_handles_invalid_file_path(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $this->reformatter->reformatTemplateFile(base_path('tests/storage/templates/does-not-exist.yml'));
+    }
+
+    /**
+     * Regression for issue #303: an input that already carries inline comments
+     * must not produce values with unclosed quotes.
+     */
+    public function test_reformatting_template_with_inline_comments_does_not_break_quotes(): void
+    {
+        $result = $this->reformatter->reformatTemplateFile($this->inlineCommentsPath);
+
+        // The original inline comment text must not survive inside the value
+        $this->assertStringNotContainsString('# Cisco IOS via TELNET without enable mode"', $result);
+        $this->assertStringNotContainsString('# Disable CLI paging"', $result);
+
+        // The name value is cleanly quoted and the rConfig comment sits outside it
+        $this->assertStringContainsString('name: "Cisco IOS - TELNET - No Enable - test 2500"', $result);
+        $this->assertStringContainsString('# Unique name for this template', $result);
+
+        // Every value line must have a balanced number of double quotes (0 or 2)
+        foreach (explode("\n", $result) as $line) {
+            if (! preg_match('/^\s{2}[a-zA-Z]/', $line)) {
+                continue;
+            }
+
+            $this->assertSame(
+                0,
+                substr_count($line, '"') % 2,
+                "Line has unbalanced quotes: {$line}"
+            );
+        }
+    }
+
+    public function test_unquoted_and_array_values_drop_their_inline_comments(): void
+    {
+        $result = $this->reformatter->reformatTemplateFile($this->inlineCommentsPath);
+
+        // Unquoted scalars keep their bare value with the original comment stripped
+        $this->assertStringContainsString('protocol: telnet ', $result);
+        $this->assertStringContainsString('port: 23 ', $result);
+        $this->assertStringNotContainsString('protocol: "telnet', $result);
+
+        // Array value is preserved without the trailing inline comment
+        $this->assertStringContainsString('setWindowSize: [240, 2048]', $result);
+        $this->assertStringNotContainsString('setWindowSize: "[240, 2048]', $result);
+    }
+
+    public function test_hash_inside_quoted_value_is_preserved(): void
+    {
+        $template = "main:\n  name: \"Cisco #1 Core\"   # inline note\n  desc: \"edge\"\n";
+
+        $result = $this->reformatter->reformatTemplate($template);
+
+        $this->assertStringContainsString('name: "Cisco #1 Core"', $result);
+        $this->assertStringNotContainsString('inline note', $result);
+    }
+}

--- a/tests/storage/templates/inlinecomments.yml
+++ b/tests/storage/templates/inlinecomments.yml
@@ -1,0 +1,29 @@
+# rConfig connection template – DO NOT EDIT DIRECTLY
+## Template Notes:
+## - All free text values must be wrapped in double quotes: " "
+## - Documentation: https://v8coredocs.rconfig.com/devices/templates/
+## - Community templates and contributions: https://github.com/rconfig/rConfig-templates
+
+main:
+  name: "Cisco IOS - TELNET - No Enable - test 2500"              # Cisco IOS via TELNET without enable mode
+  desc: "Cisco IOS TELNET based connection without enable mode"
+
+connect:
+  timeout: 10                                         # Connection timeout (in seconds)
+  protocol: telnet                                    # Protocol: telnet
+  port: 23                                            # Port number
+
+auth:
+  username: "User:"                               # Username prompt
+  password: "Password:"            # Password prompt
+  enable: off                                         # Enable mode not required
+  enableCmd: "enable"                                 # Enable command (ignored if enable is off)
+
+config:
+  linebreak: "\r\n"                                      # Linebreak format (default: 'n')
+  paging: off                                       # Disable CLI paging
+  pagingCmd: "config paging disable"                      # Command to disable paging
+  pagerPrompt: ""                                     # DEPRECATED: This value is ignored
+  saveConfig: "wr mem"                                # Command to save configuration
+  exitCmd: "logout"                                     # Command to exit session
+  setWindowSize: [240, 2048]                          # Terminal window size

--- a/tests/storage/templates/newformat.yml
+++ b/tests/storage/templates/newformat.yml
@@ -1,0 +1,26 @@
+# rConfig connection template – DO NOT EDIT DIRECTLY
+## Template Notes:
+## - All free text values must be wrapped in double quotes: " "
+## - Documentation: https://v8coredocs.rconfig.com/devices/templates/
+## - Community templates and contributions: https://github.com/rconfig/rConfig-templates
+
+main:
+  name: "SSH Private Key Template"         # Unique name for this template
+  desc: "SSH Private Key Template"         # UI description
+
+connect:
+  timeout: 10                              # Connection timeout (in seconds)
+  protocol: ssh                            # Protocol to use: 'telnet' or 'ssh'
+  port: 22                                 # Port number for connection (1–65535)
+
+auth:
+  sshPrivKey: on                           # SSH Private Key authentication enabled
+  username: "Username:"                    # Prompt string for username
+  password: "Password:"                    # Prompt string for password
+  enable: off                              # Enable mode? Set to 'on' or 'off'
+
+config:
+  linebreak: "n"                           # Linebreak setting: 'n' (default) or 'r'
+  paging: off                              # Set to 'on' to disable paging
+  saveConfig: "wr mem"                     # Command to save running config
+  exitCmd: "quit"                          # Command to end session

--- a/tests/storage/templates/oldformat.yml
+++ b/tests/storage/templates/oldformat.yml
@@ -1,0 +1,56 @@
+# rConfig connection template - DO NOT EDIT DIRECTLY
+## Notes:
+## Remember to update permissions for the templates folder after uploading new template files.
+## all items below that contain free text should be contained within quotation marks " "
+## For new community submitted templates visit: https://github.com/rconfig/rConfig-templates
+
+main:
+  name: 'SSH Private Key Template'
+  desc: 'SSH Private Key Template'
+connect:
+  # connection timeout in seconds
+  timeout: 10
+  # type either telnet or ssh - must be in lowercase
+  protocol: ssh
+  # type port number for connection protocol choose from 1 - 65535
+  port: 22
+auth:
+  sshPrivKey: on
+  # Set username name prompt. Must be in quotes. If left blank, username will not be sent.
+  username: 'Username:'
+  # Set password name prompt. Must be in quotes
+  password: 'Password:'
+  # Set enable mode on or off
+  enable: off
+  # set enable mode command. Must be in quotes
+  enableCmd: 'enable'
+  # set enable mode password prompt. Must be in quotes
+  enablePassPrmpt: 'Password:'
+  # set HP 'press any key' status. Is 'on' or 'off'
+  hpAnyKeyStatus: off
+  # set HP 'press any key' prompt.
+  hpAnyKeyPrmpt: 'Press any key to continue'
+config:
+  # Experimental: Some vendors use different linebreak settings. Choose 'n' (default) or 'r'
+  linebreak: 'n'
+  # Disable config scrolling/ paging command. on/off
+  paging: off
+  # Disable config scrolling/ paging command.
+  pagingCmd: 'terminal length 0'
+  # re-enable config scrolling/ paging command.
+  resetPagingCmd: 'terminal length 40'
+  # Set pager prompt.
+  pagerPrompt: '--More--'
+  # Set pager prompt key-stroke.
+  pagerPromptCmd: ' '
+  # Save configuration command.
+  saveConfig: 'wr mem'
+  # Set exit command.
+  exitCmd: 'quit'
+options:
+  # AnsiHost required in special cases for HP and Mikrotik devices.
+  AnsiHost: 'yes'
+  # Sets the number of columns and rows for the terminal window size
+  setWindowSize: [240, 2048]
+  # Sets the terminal window size if this is an Ansi Session.
+  setTerminalDimensions: [260, 100000]


### PR DESCRIPTION
## Summary

Fixes the template **Reformat Code** feature (`TemplateReformatter`, `/api/reformat-template`), which produced values with unclosed quotes for any template that already contained **inline comments** (a comment on the same line as a value). The output was invalid YAML and the template would not work.

Closes #303
Linear: RCO-1024

## Root cause

`parseYamlLike()` captured everything after the key (value **and** inline comment) as the value, stripped only the leading quote, then re-wrapped the whole string and appended a second mapped comment. The parser was only designed for the old format, which placed comments on their own lines.

Example of the broken output:

```
name: "Cisco IOS - TELNET - No Enable - test 2500"  # ... without enable mode" # Unique name for this template
timeout: "10   # Connection timeout (in seconds)" # Connection timeout (in seconds)
```

## Fix

Added a quote-aware `stripInlineComment()` helper, run before value parsing:

- Quoted values: keep the quoted segment, drop anything after the closing quote (a `#` inside the quotes is preserved).
- Unquoted values: cut at the first whitespace-`#`.
- Arrays with trailing inline comments now parse correctly.

## Tests

New `TemplateReformatterTest` (Fasttests) with `oldformat` / `newformat` / `inlinecomments` fixtures:

- #303 regression: asserts balanced quotes on every value line of a reformatted inline-comment template.
- Unquoted and array values drop their inline comments.
- A `#` inside a quoted value is preserved.
- Existing old-to-new conversion and format-detection coverage.

All 9 tests pass. Pint and PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)