### PR TITLE
fix: render task report times in configured timezone + validate timezone (RCO-1025)

### DIFF
--- a/app/Http/Requests/StoreSettingsTimezoneRequest.php
+++ b/app/Http/Requests/StoreSettingsTimezoneRequest.php
@@ -26,13 +26,13 @@ class StoreSettingsTimezoneRequest extends FormRequest
     {
         if ($this->getMethod() == 'POST') {
             $rules = [
-                'timezone' => 'required',
+                'timezone' => 'required|timezone',
             ];
         }
 
         if ($this->getMethod() == 'PATCH') {
             $rules = [
-                'timezone' => 'required',
+                'timezone' => 'required|timezone',
             ];
         }
 

--- a/app/Models/Taskdownloadreport.php
+++ b/app/Models/Taskdownloadreport.php
@@ -13,14 +13,18 @@ class Taskdownloadreport extends Model
 
     protected $dates = ['created_at', 'updated_at', 'start_time', 'end_time'];
 
-    public function getCreatedAtAttribute($value)
+    /**
+     * Render the report's created_at in the application's configured timezone.
+     *
+     * The stored value is reinterpreted onto the configured timezone so the
+     * download time shown in task reports matches local time rather than UTC.
+     */
+    public function getCreatedAtAttribute(?string $value): string
     {
         $timezone = Config::get('app.timezone');
 
-        return Carbon::createFromTimestamp(strtotime($value))
-            // ->timezone($timezone)
-            ->addHours($timezone)
-            ->format('M d, Y G:iA'); // Feb 23, 2015 12:32 am
-        // ->toDateTimeString();
+        return Carbon::createFromTimestamp(strtotime((string) $value))
+            ->setTimezone($timezone)
+            ->format('M d, Y G:iA'); // Jun 13, 2026 2:00AM
     }
 }

--- a/tests/Fasttests/ControllersTests/Api/SettingsTimezoneControllerTest.php
+++ b/tests/Fasttests/ControllersTests/Api/SettingsTimezoneControllerTest.php
@@ -60,4 +60,21 @@ class SettingsTimezoneControllerTest extends TestCase
         $this->assertEquals('Europe/Dublin', \Config::get('app.timezone'));
         $this->assertEquals('Europe/Dublin', env('TIMEZONE'));
     }
+
+    /**
+     * Regression for issue #251: an invalid timezone must be rejected. If it reached
+     * app.timezone the scheduler would silently fall back to UTC and run tasks at the
+     * wrong time.
+     */
+    public function test_update_timezone_rejects_invalid_timezone()
+    {
+        $response = $this->patchJson('/api/settings/timezone/1', ['timezone' => 'Not/AZone']);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('timezone');
+        $this->assertDatabaseMissing('settings', [
+            'id' => 1,
+            'timezone' => 'Not/AZone',
+        ]);
+    }
 }

--- a/tests/Fasttests/ControllersTests/Api/TaskReportControllerTest.php
+++ b/tests/Fasttests/ControllersTests/Api/TaskReportControllerTest.php
@@ -7,6 +7,8 @@ use App\Models\Config;
 use App\Models\Taskdownloadreport;
 use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Config as ConfigFacade;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use stdClass;
@@ -76,6 +78,67 @@ class TaskReportControllerTest extends TestCase
         $this->assertFileExists(report_path() . $report_data->file_name);
         File::delete(report_path() . $report_data->file_name);
         $this->assertFileDoesNotExist(report_path() . $report_data->file_name);
+    }
+
+    /**
+     * Regression for issue #251: the report download time must be rendered in the
+     * configured application timezone, not UTC. Previously the accessor called
+     * ->addHours($timezone) with a timezone string, which cast to 0 and disabled
+     * the conversion, so reports showed UTC and tasks appeared to run at the wrong time.
+     */
+    public function test_created_at_is_rendered_in_configured_timezone()
+    {
+        $originalDefault = date_default_timezone_get();
+
+        try {
+            // Simulate a user whose configured timezone has a non-zero UTC offset.
+            ConfigFacade::set('app.timezone', 'Europe/Rome');
+            date_default_timezone_set('Europe/Rome');
+
+            $report = Taskdownloadreport::factory()->create();
+
+            // Force a known local wall-clock time (02:00 Rome local on a CEST date, UTC+2).
+            DB::table('taskdownloadreports')
+                ->where('id', $report->id)
+                ->update(['created_at' => '2026-06-13 02:00:00']);
+
+            $rendered = Taskdownloadreport::find($report->id)->created_at;
+
+            // It must show the local time the task ran, not the UTC equivalent.
+            $this->assertSame('Jun 13, 2026 2:00AM', $rendered);
+            $this->assertNotSame('Jun 13, 2026 0:00AM', $rendered);
+        } finally {
+            date_default_timezone_set($originalDefault);
+        }
+    }
+
+    /**
+     * The report time must reflect the local wall-clock value as stored, even when the
+     * UTC equivalent falls on the previous day. The old code rendered the UTC value,
+     * which could roll the date back a day for positive offsets.
+     */
+    public function test_created_at_renders_local_time_across_date_rollover()
+    {
+        $originalDefault = date_default_timezone_get();
+
+        try {
+            // Sydney is UTC+10 in June, so 09:15 local is 23:15 UTC on the previous day.
+            ConfigFacade::set('app.timezone', 'Australia/Sydney');
+            date_default_timezone_set('Australia/Sydney');
+
+            $report = Taskdownloadreport::factory()->create();
+            DB::table('taskdownloadreports')
+                ->where('id', $report->id)
+                ->update(['created_at' => '2026-06-13 09:15:00']);
+
+            $rendered = Taskdownloadreport::find($report->id)->created_at;
+
+            $this->assertSame('Jun 13, 2026 9:15AM', $rendered);
+            // The old UTC rendering would have been the previous day.
+            $this->assertNotSame('Jun 12, 2026 11:15PM', $rendered);
+        } finally {
+            date_default_timezone_set($originalDefault);
+        }
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Fixes #251 · Linear RCO-1025

Customer in Europe/Rome reported tasks "run at the wrong time" after upgrading to V8: the UI mixes UTC and local time and download reports are an hour (two in summer) off. Validated as two distinct timezone bugs. **Both also exist in Pro (`rconfig8`) — same code; a follow-up will port these fixes there.**

## Bug 1 — Report download time rendered in UTC
`Taskdownloadreport::getCreatedAtAttribute()` called `->addHours($timezone)` with a timezone **string** (e.g. `"Europe/Rome"`), which Carbon casts to `0` — a no-op. The intended `->timezone($timezone)` conversion was commented out. Since `createFromTimestamp()` returns a UTC Carbon, reports rendered in UTC. Reproduced: a task that ran at `02:00` Rome local rendered as `0:00AM`.

**Fix:** use `->setTimezone($timezone)` so report times show in the configured app timezone.

## Bug 2 — No validation of the configured timezone
The scheduler evaluates cron in the configured app timezone correctly (`date_default_timezone_set(config('app.timezone'))`). But `StoreSettingsTimezoneRequest` only validated `required`. If a malformed timezone reaches `app.timezone`, `date_default_timezone_set()` fails and PHP silently falls back to **UTC**, running every task at the wrong time.

**Fix:** validate `required|timezone`. All 111 keys in the app's timezone dropdown are valid PHP identifiers, so no legitimate selection is rejected.

## Tests
- `TaskReportControllerTest`: report time renders in configured timezone, incl. a positive-offset date-rollover case (Sydney).
- `SettingsTimezoneControllerTest`: invalid timezone rejected (422) and never written.

Both confirmed to fail against the old code. Pint + PHPStan (level 0) clean.

## Not changed (latent risk noted in RCO-1025)
`SettingTimezoneController` escapes the timezone with `str_replace('/', '\/\\', ...)` before `env:set`. Traced end-to-end: Symfony's `StringInput` strips the backslashes so `.env` ends up clean — fragile but not currently corrupting anything. Candidate for follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)