### PR TITLE
Release 8.2.2: dashboard widgets top-nav button + timezone fix

### DIFF
--- a/app/Http/Controllers/Api/SettingTimezoneController.php
+++ b/app/Http/Controllers/Api/SettingTimezoneController.php
@@ -4,7 +4,10 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Requests\StoreSettingsTimezoneRequest;
 use App\Models\Setting;
-use Artisan;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 
 class SettingTimezoneController extends ApiBaseController
 {
@@ -24,14 +27,36 @@ class SettingTimezoneController extends ApiBaseController
         return parent::show($id);
     }
 
-    public function update($id, StoreSettingsTimezoneRequest $request)
+    public function update($id, StoreSettingsTimezoneRequest $request): JsonResponse
     {
-        $timezone = str_replace('/', '\/\\', $request->timezone);
-        Artisan::call('env:set TIMEZONE="' . $timezone . '"');
-        if (! App()->environment('testing')) {
-            Artisan::call('config:cache'); // cannot to a config:cache when testing. This causes a full page reload on the front end
+        $envPath = App::environmentFilePath();
+
+        // The actual application timezone lives in .env (config('app.timezone')). If the web
+        // server user cannot write it, the scheduler and dashboard keep using the old timezone
+        // while the settings page shows the new one. Fail loudly with an actionable message
+        // instead of silently leaving the timezones mismatched.
+        if (! is_writable($envPath)) {
+            return $this->failureResponse('The .env file is not writable by the web server, so the timezone could not be saved. Update the file permissions and try again.');
         }
 
-        return parent::updateResource($id, $request->toDTO()->toArray());
+        try {
+            // The timezone is already validated against the timezone list, so it is safe to
+            // pass through as-is. No slash escaping is needed for the .env file.
+            Artisan::call('env:set', ['key' => 'TIMEZONE', 'value' => $request->timezone]);
+
+            if (! App::environment('testing')) {
+                Artisan::call('config:cache'); // cannot config:cache when testing; it triggers a full page reload on the front end
+            }
+
+            parent::updateResource($id, $request->toDTO()->toArray());
+
+            // The dashboard system-info card caches config('app.timezone') for a week. Bust it
+            // so the new timezone is reflected immediately instead of after the cache expires.
+            Cache::forget('dashboard.sysinfo');
+
+            return $this->successResponse('Timezone updated successfully');
+        } catch (\Throwable $e) {
+            return $this->failureResponse('Could not update the timezone: ' . $e->getMessage());
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rconfig/rconfig",
     "type": "project",
     "description": "rConfig V8 Core",
-    "version": "8.2.0",
+    "version": "8.2.1",
     "keywords": [
         "framework",
         "laravel"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rconfig/rconfig",
     "type": "project",
     "description": "rConfig V8 Core",
-    "version": "8.2.1",
+    "version": "8.2.2",
     "keywords": [
         "framework",
         "laravel"

--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
     'name' => env('APP_NAME', 'rConfig v8 Core'),
     // run test before updating the version
-    'version' => '8.2.0',
+    'version' => '8.2.1',
     'force_https' => env('APP_FORCE_HTTPS', false),
 
     /*

--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
     'name' => env('APP_NAME', 'rConfig v8 Core'),
     // run test before updating the version
-    'version' => '8.2.1',
+    'version' => '8.2.2',
     'force_https' => env('APP_FORCE_HTTPS', false),
 
     /*

--- a/resources/js/layouts/NavigationTop.vue
+++ b/resources/js/layouts/NavigationTop.vue
@@ -11,6 +11,7 @@ import { HelpCircle, Sun, Moon, MoreVertical, Paintbrush, Star, ArrowUpCircle, C
 import { Lock } from "lucide-vue-next";
 import GenericPopover from "@/pages/Shared/Popover/GeneralPopover.vue";
 import { useVersionCheck } from "@/composables/useVersionCheck";
+import { eventBus } from "@/composables/eventBus";
 
 const colorMode = inject("colorMode");
 const panelStore = usePanelStore(); // Access the panel store
@@ -90,6 +91,13 @@ const versionStatus = computed(() => {
 const breadcrumbs = computed(() => {
 	return route.meta.breadcrumb || [];
 });
+
+// Only show the Dashboard Widgets button while on the dashboard.
+const showDashboardWidgetsButton = computed(() => route.name === "Dashboard" || route.path === "/dashboard");
+
+function handleDashboardWidgetsClick() {
+	eventBus.emit("dashboard-widgets-customize-requested");
+}
 
 const navPanelBtnState = computed(() => {
 	return panelStore.panelRef?.isCollapsed;
@@ -205,6 +213,20 @@ const showServerName = computed(() => {
 			<span v-if="showServerName" :style="{ color: serverDisplayColor }" :class="`text-${serverDisplaySize} font-semibold mr-4`">{{ serverDisplayName }}</span>
 
 			<div class="mt-1 top-nav-div flex items-center space-x-2">
+				<!-- Dashboard Widgets selector - only on the dashboard -->
+				<TooltipProvider v-if="showDashboardWidgetsButton">
+					<Tooltip>
+						<TooltipTrigger as-child>
+							<Button aria-label="Dashboard Widgets" class="hover:bg-rcgray-600 transition-colors duration-200 transform hover:scale-105" variant="ghost" @click="handleDashboardWidgetsClick()">
+								<RcIcon name="dashboard" class="absolute h-[1.2rem] w-[1.2rem] text-blue-400" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent class="text-white bg-rcgray-800 border border-blue-500/30">
+							<p>Dashboard Widgets</p>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+
 				<Button v-if="isDevMode" class="hover:bg-rcgray-600 transition-colors duration-200 transform hover:scale-105" @click="navToStyles()" variant="ghost">
 					<Paintbrush class="absolute h-[1.2rem] w-[1.2rem] text-blue-400" />
 				</Button>

--- a/resources/js/pages/Dashboard/DashboardWidgets.vue
+++ b/resources/js/pages/Dashboard/DashboardWidgets.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { ref, computed, onMounted, watch } from "vue";
-import { Button } from "@/components/ui/button";
-import { GripVertical, Plus, Settings2, Maximize2, Minimize2 } from "lucide-vue-next";
+import { ref, computed, onMounted, onBeforeUnmount, watch } from "vue";
+import { X } from "lucide-vue-next";
+import { eventBus } from "@/composables/eventBus";
 import LatestDevicesWidget from "@/pages/Dashboard/Widgets/LatestDevicesWidget.vue";
 import LatestConfigsWidget from "@/pages/Dashboard/Widgets/LatestConfigsWidget.vue";
 import QuickStatsWidget from "@/pages/Dashboard/Widgets/QuickStatsWidget.vue";
@@ -27,7 +27,6 @@ const props = defineProps({
 
 const STORAGE_KEY = 'dashboard_widgets_config';
 
-const isExpanded = ref(true);
 const editMode = ref(false);
 
 // Map component names to actual components
@@ -103,12 +102,12 @@ watch(
 	{ deep: true }
 );
 
-const toggleExpanded = () => {
-	isExpanded.value = !isExpanded.value;
-};
-
 const toggleEditMode = () => {
 	editMode.value = !editMode.value;
+};
+
+const closeEditMode = () => {
+	editMode.value = false;
 };
 
 const toggleWidget = (widgetId) => {
@@ -118,76 +117,42 @@ const toggleWidget = (widgetId) => {
 	}
 };
 
-// Load configuration on mount
+// Load configuration on mount and listen for the top nav customize button
 onMounted(() => {
 	loadWidgetConfig();
+	eventBus.on("dashboard-widgets-customize-requested", toggleEditMode);
+});
+
+onBeforeUnmount(() => {
+	eventBus.off("dashboard-widgets-customize-requested", toggleEditMode);
 });
 </script>
 
 <template>
-	<div :class="[
-		'hidden xl:block transition-all duration-300',
-		isExpanded ? 'xl:col-span-12' : 'xl:col-span-4'
-	]">
-		<!-- Header Card with Controls -->
-		<div class="border-0 shadow-md rounded-2xl bg-card text-card-foreground p-4 transition-all duration-200 hover:shadow-lg mb-4">
+	<div class="hidden xl:block xl:col-span-12">
+		<!-- Widget Selector Panel - opened from the Dashboard Widgets button in the top nav -->
+		<div v-if="editMode" class="border-0 shadow-md rounded-2xl bg-card text-card-foreground p-4 transition-all duration-200 mb-4">
 			<div class="flex items-center justify-between mb-3">
-				<h3 class="text-lg font-semibold flex items-center gap-2">
-					<RcIcon name="dashboard" class="w-5 h-5" />
-					Dashboard Widgets
+				<h3 class="text-sm font-semibold flex items-center gap-2">
+					<RcIcon name="dashboard" class="w-4 h-4" />
+					Available Widgets
+					<span class="text-xs font-normal text-muted-foreground">Click to enable or disable</span>
 				</h3>
-				
-				<div class="flex items-center gap-2">
-					<button class="p-2 rounded-lg hover:bg-muted/50 transition-colors" @click="toggleEditMode" :title="editMode ? 'Close configuration' : 'Configure Widgets'">
-						<Settings2 class="w-4 h-4" />
-					</button>
-					<button class="p-2 rounded-lg hover:bg-muted/50 transition-colors" @click="toggleExpanded" :title="isExpanded ? 'Collapse' : 'Expand'">
-						<Maximize2 v-if="!isExpanded" class="w-4 h-4" />
-						<Minimize2 v-else class="w-4 h-4" />
-					</button>
-				</div>
+				<button class="p-2 rounded-lg hover:bg-muted/50 transition-colors" @click="closeEditMode" title="Done">
+					<X class="w-4 h-4" />
+				</button>
 			</div>
-
-			<!-- Edit Mode Panel -->
-			<div v-if="editMode" class="p-3 rounded-lg bg-muted/30 border border-muted">
-				<div class="flex items-center justify-between mb-2">
-					<span class="text-sm font-medium">Available Widgets</span>
-					<span class="text-xs text-muted-foreground">Click to enable/disable</span>
-				</div>
-				<div class="flex flex-wrap gap-2">
-					<button v-for="widget in availableWidgets" :key="widget.id" @click="toggleWidget(widget.id)" :class="['px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 cursor-pointer', widget.enabled ? 'bg-blue-600 text-white hover:bg-blue-700 hover:animate-pulse' : 'bg-muted text-muted-foreground hover:bg-muted/70']">
-						<span class="mr-1.5">{{ widget.enabled ? '✓' : '+' }}</span>
-						{{ widget.name }}
-					</button>
-				</div>
+			<div class="flex flex-wrap gap-2">
+				<button v-for="widget in availableWidgets" :key="widget.id" @click="toggleWidget(widget.id)" :class="['px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 cursor-pointer', widget.enabled ? 'bg-blue-600 text-white hover:bg-blue-700 hover:animate-pulse' : 'bg-muted text-muted-foreground hover:bg-muted/70']">
+					<span class="mr-1.5">{{ widget.enabled ? '✓' : '+' }}</span>
+					{{ widget.name }}
+				</button>
 			</div>
 		</div>
 
 		<!-- Widget Grid - No background wrapper -->
-		<div v-if="activeWidgets.length > 0" :class="['grid gap-4', isExpanded ? 'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3' : 'grid-cols-1']">
+		<div v-if="activeWidgets.length > 0" class="grid gap-4 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
 			<component v-for="widget in activeWidgets" :key="widget.id" :is="widgetComponents[widget.component]" :configinfo="configinfo" :healthLatest="healthLatest" :latestDevices="latestDevices" :isLoadingLatestDevices="isLoadingLatestDevices" :editMode="editMode" class="transition-all duration-200"/>
 		</div>
-
-		<!-- Empty State -->
-		<!-- <div v-if="activeWidgets.length === 0" class="border-0 shadow-md rounded-2xl bg-card text-card-foreground p-4 transition-all duration-200 hover:shadow-lg">
-			<div class="text-center py-8">
-				<div class="inline-flex p-3 rounded-full bg-muted/50 mb-3">
-					<Plus class="w-6 h-6 text-muted-foreground" />
-				</div>
-				<h4 class="text-sm font-semibold mb-1">No Widgets Active</h4>
-				<p class="text-xs text-muted-foreground mb-3">
-					Click the settings icon to add widgets
-				</p>
-				<Button 
-					class="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 hover:animate-pulse text-white"
-					size="sm" 
-					@click="editMode = true"
-					variant="primary"
-				>
-					<Settings2 class="w-4 h-4 mr-2" />
-					Configure Widgets
-				</Button>
-			</div>
-		</div> -->
 	</div>
 </template>

--- a/resources/js/pages/Settings/Panels/Components/useSystemSettingsTimezone.js
+++ b/resources/js/pages/Settings/Panels/Components/useSystemSettingsTimezone.js
@@ -61,7 +61,8 @@ export function useSystemSettingsTimezone() {
       })
       .catch(error => {
         console.log(error);
-        toastError('Error', 'Failed to set timezone');
+        const message = error.response?.data?.message || 'Failed to set timezone';
+        toastError('Error', message);
         popoverState.value = false;
       });
   }

--- a/tests/Fasttests/ControllersTests/Api/SettingsTimezoneControllerTest.php
+++ b/tests/Fasttests/ControllersTests/Api/SettingsTimezoneControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Fasttests\ControllersTests\Api;
 
 use App\Models\User;
+use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
 class SettingsTimezoneControllerTest extends TestCase
@@ -45,6 +46,7 @@ class SettingsTimezoneControllerTest extends TestCase
         $timezone = 'Pacific/Midway';
         $response = $this->patch('/api/settings/timezone/1', ['timezone' => $timezone]);
         $response->assertStatus(200);
+        $response->assertJson(['success' => true]);
         $this->assertDatabaseHas('settings', [
             'id' => 1,
             'timezone' => $timezone,
@@ -59,6 +61,42 @@ class SettingsTimezoneControllerTest extends TestCase
         \Artisan::call('config:cache'); // cannot to a config:cache when testing
         $this->assertEquals('Europe/Dublin', \Config::get('app.timezone'));
         $this->assertEquals('Europe/Dublin', env('TIMEZONE'));
+    }
+
+    /**
+     * The timezone must be written to .env without any slash escaping. A previous
+     * implementation mangled the value (Europe/Rome -> Europe\/\Rome) which only
+     * worked by accident, so guard the .env now holds the clean identifier.
+     */
+    public function test_update_timezone_writes_clean_identifier_to_env()
+    {
+        $timezone = 'Europe/Rome';
+        $response = $this->patch('/api/settings/timezone/1', ['timezone' => $timezone]);
+        $response->assertStatus(200);
+
+        $this->assertStringContainsString('TIMEZONE=Europe/Rome', file_get_contents(app()->environmentFilePath()));
+
+        // change back to Europe/Dublin
+        \Artisan::call('env:set TIMEZONE=Europe/Dublin');
+    }
+
+    /**
+     * Regression for issue #307: the dashboard system-info card caches the timezone
+     * for a week. Updating the timezone must bust that cache so the dashboard reflects
+     * the change immediately instead of showing a stale (mismatched) timezone.
+     */
+    public function test_update_timezone_busts_dashboard_sysinfo_cache()
+    {
+        Cache::put('dashboard.sysinfo', ['timezone' => 'Europe/Dublin'], 600);
+        $this->assertTrue(Cache::has('dashboard.sysinfo'));
+
+        $response = $this->patch('/api/settings/timezone/1', ['timezone' => 'Pacific/Midway']);
+        $response->assertStatus(200);
+
+        $this->assertFalse(Cache::has('dashboard.sysinfo'));
+
+        // change back to Europe/Dublin
+        \Artisan::call('env:set TIMEZONE=Europe/Dublin');
     }
 
     /**


### PR DESCRIPTION
## Summary

Releases **8.2.2** to main, bundling two changes:

- **Dashboard widget selector moved to the top nav.** Replaces the full-width dashboard header (expand/minimize plus options/filters buttons) with a single Dashboard Widgets button in the top navigation, shown only on the dashboard route. It emits an event over the existing event bus to open the widget selector panel, aligning Core with the Pro layout.
- **Timezone update fix (8.2.1 work, closes #307).** Makes the timezone update robust and reflected immediately. This was previously only on the branch and had not reached main.

## Changes
- `resources/js/layouts/NavigationTop.vue` — single, route-scoped Dashboard Widgets button emitting `dashboard-widgets-customize-requested`.
- `resources/js/pages/Dashboard/DashboardWidgets.vue` — drops the header/minimize UI; listens on the event bus to toggle the widget selector panel.
- `config/app.php` — version bumped to 8.2.2.

## Notes
- Frontend change requires `npm run build` / `npm run dev` to be visible.
- No automated tests cover this SPA interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)