### PR TITLE
closes RCO-996: Update PHPStan to level 1

### DIFF
--- a/app/Console/Commands/DataImport/NetMri/NetMriToRconfigMappingsCommand.php
+++ b/app/Console/Commands/DataImport/NetMri/NetMriToRconfigMappingsCommand.php
@@ -300,7 +300,7 @@ class NetMriToRconfigMappingsCommand extends Command
                 $tagOptions
             );
 
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");
@@ -419,7 +419,7 @@ class NetMriToRconfigMappingsCommand extends Command
                 $currentTagIds
             );
 
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");

--- a/app/Console/Commands/DataImport/Oxidized/OxidizedRconfigDeviceImportCommand.php
+++ b/app/Console/Commands/DataImport/Oxidized/OxidizedRconfigDeviceImportCommand.php
@@ -295,13 +295,6 @@ class OxidizedRconfigDeviceImportCommand extends Command
         $validDevices = [];
         $invalidDevices = [];
 
-        // Check if we have any devices to validate
-        if (empty($devices)) {
-            warning('No devices found in the import file.');
-
-            return 1;
-        }
-
         $bar = progress('Validating devices', count($devices));
 
         foreach ($devices as $index => $device) {

--- a/app/Console/Commands/DataImport/Oxidized/OxidizedToRconfigMappingsCommand.php
+++ b/app/Console/Commands/DataImport/Oxidized/OxidizedToRconfigMappingsCommand.php
@@ -130,8 +130,10 @@ class OxidizedToRconfigMappingsCommand extends Command
 
     /**
      * Display interactive menu
+     *
+     * @param  array<int|string, mixed>  $freshMappings
      */
-    protected function showMenu()
+    protected function showMenu(array $freshMappings = []): void
     {
         note('rConfig Oxidized Device Mappings');
 
@@ -332,7 +334,7 @@ class OxidizedToRconfigMappingsCommand extends Command
 
             // Now $selectedTagIds contains an array of tag IDs
             // If no tags were selected, use the first tag
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");
@@ -436,7 +438,7 @@ class OxidizedToRconfigMappingsCommand extends Command
             );
 
             // If no tags were selected, use the first tag
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");

--- a/app/Console/Commands/DataImport/Rancid/RancidToRconfigMappingsCommand.php
+++ b/app/Console/Commands/DataImport/Rancid/RancidToRconfigMappingsCommand.php
@@ -317,7 +317,7 @@ class RancidToRconfigMappingsCommand extends Command
                 $tagOptions
             );
 
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");
@@ -415,7 +415,7 @@ class RancidToRconfigMappingsCommand extends Command
                 $currentTagIds
             );
 
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");

--- a/app/Console/Commands/DataImport/Solarwinds/SolarwindsToRconfigMappingsCommand.php
+++ b/app/Console/Commands/DataImport/Solarwinds/SolarwindsToRconfigMappingsCommand.php
@@ -307,7 +307,7 @@ class SolarwindsToRconfigMappingsCommand extends Command
                 $tagOptions
             );
 
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");
@@ -445,7 +445,7 @@ class SolarwindsToRconfigMappingsCommand extends Command
                 $currentTagIds
             );
 
-            if (empty($selectedTagIds) && ! empty($tagOptions)) {
+            if (empty($selectedTagIds)) {
                 $firstTagId = array_key_first($tagOptions);
                 $selectedTags = [$firstTagId];
                 note("No tags selected. Automatically using the first tag: {$tagOptions[$firstTagId]}");

--- a/app/Console/Commands/EnvironmentSetCommand.php
+++ b/app/Console/Commands/EnvironmentSetCommand.php
@@ -119,7 +119,7 @@ class EnvironmentSetCommand extends Command
     /**
      * Parse key, value and path to .env-file from command line arguments.
      *
-     * @return string[] [string KEY, string value, ?string envFilePath].
+     * @return array{string, string, string|false|null} [string KEY, string value, ?string envFilePath].
      */
     public function parseCommandArguments(string $_key, ?string $_value, ?string $_envFilePath): array
     {

--- a/app/Http/Helpers.php
+++ b/app/Http/Helpers.php
@@ -182,6 +182,7 @@ function getOSInformation()
         return null;
     }
 
+    $osRelease = null;
     $osReleaseFile = '/etc/os-release';
     if (file_exists($osReleaseFile)) {
         $osRelease = parse_ini_file($osReleaseFile);

--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -24,6 +24,8 @@ class StoreCategoryRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'categoryName' => 'required|unique:categories|max:255|alpha_dash',

--- a/app/Http/Requests/StoreCommandRequest.php
+++ b/app/Http/Requests/StoreCommandRequest.php
@@ -23,6 +23,8 @@ class StoreCommandRequest extends FormRequest
 
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'command' => 'required|min:3|unique:commands|max:255',

--- a/app/Http/Requests/StoreDeviceCredentialsRequest.php
+++ b/app/Http/Requests/StoreDeviceCredentialsRequest.php
@@ -14,6 +14,8 @@ class StoreDeviceCredentialsRequest extends FormRequest
 
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'cred_name' => 'required|min:3|unique:device_credentials|max:255',

--- a/app/Http/Requests/StoreDeviceModelRequest.php
+++ b/app/Http/Requests/StoreDeviceModelRequest.php
@@ -25,6 +25,8 @@ class StoreDeviceModelRequest extends FormRequest
 
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'name' => [

--- a/app/Http/Requests/StoreDeviceRequest.php
+++ b/app/Http/Requests/StoreDeviceRequest.php
@@ -47,6 +47,8 @@ class StoreDeviceRequest extends FormRequest
 
     public function rules()
     {
+        $rules = [];
+
         // dd($this->request);
         if ($this->getMethod() == 'POST') {
             $rules = [

--- a/app/Http/Requests/StoreSettingsBannerRequest.php
+++ b/app/Http/Requests/StoreSettingsBannerRequest.php
@@ -24,6 +24,8 @@ class StoreSettingsBannerRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'login_banner' => 'required',

--- a/app/Http/Requests/StoreSettingsDebugRequest.php
+++ b/app/Http/Requests/StoreSettingsDebugRequest.php
@@ -24,6 +24,8 @@ class StoreSettingsDebugRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'deviceDebugging' => 'required',

--- a/app/Http/Requests/StoreSettingsDeviceCredRequest.php
+++ b/app/Http/Requests/StoreSettingsDeviceCredRequest.php
@@ -24,6 +24,8 @@ class StoreSettingsDeviceCredRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'defaultDeviceUsername' => 'required|min:3|max:255',

--- a/app/Http/Requests/StoreSettingsEmailRequest.php
+++ b/app/Http/Requests/StoreSettingsEmailRequest.php
@@ -24,6 +24,8 @@ class StoreSettingsEmailRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'deviceEmailging' => 'required',

--- a/app/Http/Requests/StoreSettingsTimezoneRequest.php
+++ b/app/Http/Requests/StoreSettingsTimezoneRequest.php
@@ -24,6 +24,8 @@ class StoreSettingsTimezoneRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'timezone' => 'required|timezone',

--- a/app/Http/Requests/StoreTagRequest.php
+++ b/app/Http/Requests/StoreTagRequest.php
@@ -24,6 +24,8 @@ class StoreTagRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'tagname' => 'required|unique:tags| max:50',

--- a/app/Http/Requests/StoreTaskRequest.php
+++ b/app/Http/Requests/StoreTaskRequest.php
@@ -53,6 +53,8 @@ class StoreTaskRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'task_name' => 'required|min:3|unique:tasks|max:255',

--- a/app/Http/Requests/StoreTemplateRequest.php
+++ b/app/Http/Requests/StoreTemplateRequest.php
@@ -14,6 +14,8 @@ class StoreTemplateRequest extends FormRequest
 
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'templateName' => 'required|max:255',

--- a/app/Http/Requests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreUserRequest.php
@@ -24,6 +24,8 @@ class StoreUserRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'name' => 'required|max:255',

--- a/app/Http/Requests/StoreVendorRequest.php
+++ b/app/Http/Requests/StoreVendorRequest.php
@@ -24,6 +24,8 @@ class StoreVendorRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'vendorName' => 'required|unique:vendors| max:255',

--- a/app/Http/Requests/UpdateTaskRequest.php
+++ b/app/Http/Requests/UpdateTaskRequest.php
@@ -52,6 +52,8 @@ class UpdateTaskRequest extends FormRequest
      */
     public function rules()
     {
+        $rules = [];
+
         if ($this->getMethod() == 'PATCH') {
             $rules = [
                 'task_name' => 'required|min:3|max:255',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -167,3 +167,29 @@ parameters:
 			identifier: larastan.noEnvCallsOutsideOfConfig
 			count: 6
 			path: app/Support/Saml/SamlConfigResolver.php
+		# Pro-shared latent issues surfaced by the level 1 upgrade. These same call sites exist
+		# unfixed in ../rconfig8 (Pro); fixing them here would change runtime behaviour and diverge
+		# Core from Pro, so they are baselined pending a coordinated fix across both editions.
+		-
+			message: '#^Call to an undefined method App\\Http\\Controllers\\Api\\DashboardController\:\:checkOrSetAppUrlNotification\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Controllers/Api/DashboardController.php
+
+		-
+			message: '#^Class Spatie\\Health\\ResultStores\\StoredCheckResults\\StoredCheckResult constructor invoked with 7 parameters, 1\-6 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: app/Http/Controllers/Api/SystemHealthController.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Api\\ApiBaseController\:\:show\(\) invoked with 4 parameters, 1\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: app/Http/Controllers/Api/TagController.php
+
+		-
+			message: '#^Static method Spatie\\QueryBuilder\\AllowedFilter\:\:custom\(\) invoked with 4 parameters, 2\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: app/Http/Controllers/Api/TaskController.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 0
+    level: 1
 
     # Stable, repo-relative location for the result cache so CI can cache it between runs.
     tmpDir: .phpstan


### PR DESCRIPTION
## Summary

Raises Larastan/PHPStan from **level 0 to level 1**. Level 1 surfaced 33 new errors; 29 are fixed cleanly and 4 are baselined.

### Fixed (29, behaviour-preserving)
- **16 Request classes** — initialise `$rules = []` so the fallthrough path is always defined.
- **DataImport mapping commands** — remove redundant `empty()` guards (`$tagOptions`, `$devices`) already covered by earlier checks.
- **Helpers.php** — initialise `$osRelease = null` before the `file_exists` branches.
- **EnvironmentSetCommand** — correct `parseCommandArguments()` PHPDoc to an accurate `array{string, string, string|false|null}` shape.
- **OxidizedToRconfigMappingsCommand** — add the optional `array $freshMappings = []` param the call sites already pass.

### Baselined (4)
Genuine latent issues that also exist unfixed in Pro (`../rconfig8`); baselined to keep Core aligned with Pro pending a coordinated fix:
- `DashboardController::checkOrSetAppUrlNotification()` (undefined in both editions)
- `SystemHealthController` — `StoredCheckResult` arity
- `TagController` — `ApiBaseController::show()` arity
- `TaskController` — `AllowedFilter::custom()` arity

## Verification
- `composer stan` → **No errors** at level 1
- `vendor/bin/pint --dirty` → passed
- Category/Task/Device controller tests (exercise the `rules()` paths) → 51 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)