### PR TITLE
chore: bump version to 8.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rconfig/rconfig",
     "type": "project",
     "description": "rConfig V8 Core",
-    "version": "8.2.3",
+    "version": "8.2.4",
     "keywords": [
         "framework",
         "laravel"

--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
     'name' => env('APP_NAME', 'rConfig v8 Core'),
     // run test before updating the version
-    'version' => '8.2.3',
+    'version' => '8.2.4',
     'force_https' => env('APP_FORCE_HTTPS', false),
 
     /*


### PR DESCRIPTION
Bump the application version from 8.2.3 to 8.2.4 ahead of the 8.2.4 release tag.

- `composer.json`: 8.2.3 → 8.2.4
- `config/app.php`: 8.2.3 → 8.2.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)