### PR TITLE
Read flashmessage prop in LoginComponent so login/SSO errors are visible

### DIFF
--- a/resources/js/pages/Auth/LoginComponent.vue
+++ b/resources/js/pages/Auth/LoginComponent.vue
@@ -6,11 +6,20 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import axios from 'axios';
 
+// Server-flashed message (e.g. SSO callback errors) passed in from the
+// Blade view via <login-component flashmessage="{{ session('message') }}">.
+// Without reading this prop, server-side redirects with a flashed
+// session('message') -- such as every SocialAuthHandler error path --
+// silently never reach the user.
+const props = defineProps<{
+	flashmessage?: string;
+}>();
+
 // Form state
 const username = ref('');
 const password = ref('');
 const isLoading = ref(false);
-const errorMessage = ref('');
+const errorMessage = ref(props.flashmessage || '');
 
 const socialProviders = ref({
 	microsoft: false,


### PR DESCRIPTION
## Problem

`resources/views/auth/login.blade.php` passes the server-flashed session message into the Vue login component:

<login-component flashmessage="{{ session('message') }}"></login-component>

But `LoginComponent.vue` never declared `defineProps` for `flashmessage` — it's never read anywhere in the component. Confirmed via raw HTML inspection that the attribute correctly contains the message (e.g. `flashmessage="Authorization code is missing. Please try again."`), but nothing in the component ever displays it.

This means every server-side redirect that flashes a `message` and lands on `/login` was invisible to the user — currently affects every error path in `SocialAuthHandler`/`SocialiteController` (missing code/SAMLResponse, denied, provider failure, account not registered, unapproved account, login exception). Regular username/password login failures are unaffected, since those use a separate client-side AJAX error path.

Fixes #338

## Fix

Declares the prop and initializes the existing `errorMessage` ref from it, reusing the component's existing error-display markup — no new UI code needed:

const props = defineProps<{
  flashmessage?: string;
}>();

const errorMessage = ref(props.flashmessage || '');

## Testing

Manually verified in a browser (built assets with `npm run build`) against the following callback URLs, confirming the correct message now renders on `/login`:

- `/auth/callback/google` (missing code) → "Authorization code is missing. Please try again."
- `/auth/callback/google?code=fake&denied=true` → "Access was denied. Please try again."
- `/auth/callback/saml2` (missing SAMLResponse) → "SAML response is missing. Please try again."

Before this fix, all three of the above landed on `/login` with no message displayed at all, despite the backend correctly flashing the message and it being present in the raw HTML.

## Notes

Pre-existing issue predating all SSO-related work in this repo — confirmed via `git log`/`git blame` that `login.blade.php`'s `flashmessage` attribute has been unchanged since the file was first created (2023-03-14), and `LoginComponent.vue` has never, at any point in its history, declared `defineProps` for it. Not introduced by #330/#334/#335; discovered while manually testing those fixes in a browser.