### PR TITLE
Add health check email notification settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,6 +188,19 @@ MASK_DEVICE_CREDENTIALS=false
 
 
 #==============================================================================
+# Health Check Notifications
+#==============================================================================
+# Recipient and sender details for automated health-check email alerts.
+# These are independent of the main application mail settings configured via
+# the rConfig Settings UI.
+# Leaving this blank overrides the application's internal fallback and will 
+# silently suppress health-check notifications.
+HEALTH_MAIL_TO=
+MAIL_FROM_ADDRESS=
+MAIL_FROM_NAME=rConfig
+
+
+#==============================================================================
 # SAML2 / Shibboleth SSO
 #==============================================================================
 # Enterprise SSO via SAML2. [OPTIONAL]


### PR DESCRIPTION
Added configuration options for health check email notifications in .env.example, following the change to https://github.com/rconfig/rconfig/pull/346