### PR TITLE
Mask device credential secrets on the external REST API

### DIFF
--- a/app/Http/Controllers/Api/DeviceCredentialsController.php
+++ b/app/Http/Controllers/Api/DeviceCredentialsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Requests\StoreDeviceCredentialsRequest;
 use App\Models\DeviceCredentials;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -17,15 +18,25 @@ class DeviceCredentialsController extends ApiBaseController
 
     public function index(Request $request, $searchCols = null, $relationship = null, $withCount = null)
     {
+        return response()->json($this->paginateCredentials($request));
+    }
 
-        $response = QueryBuilder::for(DeviceCredentials::class)
+    /**
+     * Build the paginated credential listing shared by the internal and external APIs.
+     *
+     * Kept separate from index() so the external REST API can mask secrets on the way out
+     * without duplicating the query definition.
+     *
+     * @return LengthAwarePaginator<int, DeviceCredentials>
+     */
+    protected function paginateCredentials(Request $request): LengthAwarePaginator
+    {
+        return QueryBuilder::for(DeviceCredentials::class)
             ->with('device')
             ->allowedFilters(...['cred_name'])
             ->defaultSort('-id')
             ->allowedSorts(...['id', 'cred_name'])
             ->paginate((int) $request->perPage);
-
-        return response()->json($response);
     }
 
     public function store(StoreDeviceCredentialsRequest $request)

--- a/app/Http/Controllers/Api/v1/DeviceCredentialsController.php
+++ b/app/Http/Controllers/Api/v1/DeviceCredentialsController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api\v1;
 
 use App\Http\Controllers\Api\DeviceCredentialsController as BaseDeviceCredentialsController;
+use App\Traits\MaskableCredentials;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 /**
  * @group Device Credentials
@@ -11,5 +14,59 @@ use App\Http\Controllers\Api\DeviceCredentialsController as BaseDeviceCredential
  */
 class DeviceCredentialsController extends BaseDeviceCredentialsController
 {
-    // Inherits index/show/store/update/destroy from the application device credentials controller.
+    use MaskableCredentials;
+
+    /**
+     * Secret fields that must never leave the external REST API in cleartext.
+     *
+     * @var array<int, string>
+     */
+    private const MASKED_FIELDS = ['cred_password', 'cred_enable_password'];
+
+    /**
+     * List credential sets with their secrets masked.
+     *
+     * Masking is unconditional here. The MASK_DEVICE_CREDENTIALS setting governs the
+     * device endpoints only and must not be able to re-enable cleartext secrets on the
+     * token authenticated API.
+     */
+    public function index(Request $request, $searchCols = null, $relationship = null, $withCount = null): JsonResponse
+    {
+        $credentials = $this->paginateCredentials($request)
+            ->through(fn ($credential): array => $this->maskSecrets($credential->toArray()));
+
+        return response()->json($credentials);
+    }
+
+    /**
+     * Show a single credential set with its secrets masked.
+     *
+     * @return array<string, mixed>
+     */
+    public function show($id, $relationship = null, $withCount = null): array
+    {
+        return $this->maskSecrets(parent::show($id)->toArray());
+    }
+
+    /**
+     * Replace secret values with a masked form, leaving blank secrets untouched.
+     *
+     * Blank-like values are left as they are so callers can still tell a credential set
+     * has no enable password, rather than seeing stars that imply one exists.
+     *
+     * @param  array<string, mixed>  $credential
+     * @return array<string, mixed>
+     */
+    private function maskSecrets(array $credential): array
+    {
+        foreach (self::MASKED_FIELDS as $field) {
+            $value = $credential[$field] ?? null;
+
+            if (is_string($value) && $value !== '') {
+                $credential[$field] = $this->mask($value);
+            }
+        }
+
+        return $credential;
+    }
 }

--- a/tests/Fasttests/ControllersTests/Api/RestApi/DeviceCredentialsApiV1MaskingTest.php
+++ b/tests/Fasttests/ControllersTests/Api/RestApi/DeviceCredentialsApiV1MaskingTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Fasttests\ControllersTests\Api\RestApi;
+
+use App\Models\DeviceCredentials;
+use App\Models\RestApiToken;
+use App\Models\User;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+/**
+ * Regression cover for cleartext device credential exposure on the external REST API.
+ *
+ * The token authenticated v1 API must never return usable device passwords. Secrets are
+ * masked unconditionally, independent of the MASK_DEVICE_CREDENTIALS setting, which only
+ * governs the device endpoints.
+ */
+class DeviceCredentialsApiV1MaskingTest extends TestCase
+{
+    protected RestApiToken $token;
+
+    private const CLEARTEXT_PASSWORD = 'SuperSecretDevicePassword99';
+
+    private const CLEARTEXT_ENABLE_PASSWORD = 'SuperSecretEnablePassword88';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->beginTransaction();
+
+        User::factory()->create();
+        $this->token = RestApiToken::factory()->create();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function authHeader(): array
+    {
+        return ['apitoken' => $this->token->api_token];
+    }
+
+    private function createCredential(): DeviceCredentials
+    {
+        return DeviceCredentials::factory()->create([
+            'cred_name' => 'masking-target',
+            'cred_username' => 'netadmin',
+            'cred_password' => self::CLEARTEXT_PASSWORD,
+            'cred_enable_password' => self::CLEARTEXT_ENABLE_PASSWORD,
+        ]);
+    }
+
+    public function test_index_does_not_expose_cleartext_secrets(): void
+    {
+        $this->createCredential();
+
+        $response = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials?perPage=50')
+            ->assertStatus(200);
+
+        $this->assertStringNotContainsString(self::CLEARTEXT_PASSWORD, $response->getContent());
+        $this->assertStringNotContainsString(self::CLEARTEXT_ENABLE_PASSWORD, $response->getContent());
+    }
+
+    public function test_index_returns_masked_secrets(): void
+    {
+        $this->createCredential();
+
+        $response = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials?perPage=50')
+            ->assertStatus(200);
+
+        $this->assertStringContainsString('*', (string) $response->json('data.0.cred_password'));
+        $this->assertStringContainsString('*', (string) $response->json('data.0.cred_enable_password'));
+    }
+
+    public function test_index_still_returns_identifying_fields(): void
+    {
+        $this->createCredential();
+
+        $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials?perPage=50')
+            ->assertStatus(200)
+            ->assertJsonFragment(['cred_name' => 'masking-target'])
+            ->assertJsonFragment(['cred_username' => 'netadmin']);
+    }
+
+    public function test_show_does_not_expose_cleartext_secrets(): void
+    {
+        $cred = $this->createCredential();
+
+        $response = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials/' . $cred->id)
+            ->assertStatus(200);
+
+        $this->assertStringNotContainsString(self::CLEARTEXT_PASSWORD, $response->getContent());
+        $this->assertStringNotContainsString(self::CLEARTEXT_ENABLE_PASSWORD, $response->getContent());
+    }
+
+    public function test_show_returns_masked_secrets(): void
+    {
+        $cred = $this->createCredential();
+
+        $response = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials/' . $cred->id)
+            ->assertStatus(200);
+
+        $this->assertStringContainsString('*', (string) $response->json('cred_password'));
+        $this->assertStringContainsString('*', (string) $response->json('cred_enable_password'));
+    }
+
+    public function test_masking_applies_when_mask_device_credentials_is_disabled(): void
+    {
+        Config::set('rConfig.mask_device_credentials', false);
+        $cred = $this->createCredential();
+
+        $index = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials?perPage=50')
+            ->assertStatus(200);
+
+        $show = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials/' . $cred->id)
+            ->assertStatus(200);
+
+        $this->assertStringNotContainsString(self::CLEARTEXT_PASSWORD, $index->getContent());
+        $this->assertStringNotContainsString(self::CLEARTEXT_PASSWORD, $show->getContent());
+    }
+
+    public function test_blank_enable_password_is_left_untouched(): void
+    {
+        $cred = DeviceCredentials::factory()->create([
+            'cred_password' => self::CLEARTEXT_PASSWORD,
+            'cred_enable_password' => '',
+        ]);
+
+        $response = $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials/' . $cred->id)
+            ->assertStatus(200);
+
+        // A blank secret decodes to false through EncryptStringCast (pre-existing quirk),
+        // so accept every blank-like shape here. Masking must not turn it into stars.
+        $this->assertContains($response->json('cred_enable_password'), [null, '', 0, '0', false]);
+    }
+
+    public function test_store_response_does_not_echo_cleartext_secrets(): void
+    {
+        $response = $this->withHeaders($this->authHeader())
+            ->postJson('/api/v1/device-credentials', [
+                'cred_name' => 'store-masking-' . uniqid(),
+                'cred_description' => 'Created via REST API masking test',
+                'cred_username' => 'admin',
+                'cred_password' => self::CLEARTEXT_PASSWORD,
+                'cred_enable_password' => self::CLEARTEXT_ENABLE_PASSWORD,
+            ])
+            ->assertStatus(200);
+
+        $this->assertStringNotContainsString(self::CLEARTEXT_PASSWORD, $response->getContent());
+        $this->assertStringNotContainsString(self::CLEARTEXT_ENABLE_PASSWORD, $response->getContent());
+    }
+
+    public function test_update_response_does_not_echo_cleartext_secrets(): void
+    {
+        $cred = $this->createCredential();
+
+        $response = $this->withHeaders($this->authHeader())
+            ->patchJson('/api/v1/device-credentials/' . $cred->id, [
+                'cred_name' => 'update-masking-' . uniqid(),
+                'cred_description' => 'updated',
+                'cred_username' => 'admin2',
+                'cred_password' => self::CLEARTEXT_PASSWORD,
+                'cred_enable_password' => self::CLEARTEXT_ENABLE_PASSWORD,
+                'cred_is_default' => 0,
+            ])
+            ->assertStatus(200);
+
+        $this->assertStringNotContainsString(self::CLEARTEXT_PASSWORD, $response->getContent());
+        $this->assertStringNotContainsString(self::CLEARTEXT_ENABLE_PASSWORD, $response->getContent());
+    }
+
+    public function test_secrets_are_still_stored_intact_behind_the_mask(): void
+    {
+        $cred = $this->createCredential();
+
+        $this->withHeaders($this->authHeader())
+            ->getJson('/api/v1/device-credentials/' . $cred->id)
+            ->assertStatus(200);
+
+        $stored = DeviceCredentials::findOrFail($cred->id);
+
+        $this->assertSame(self::CLEARTEXT_PASSWORD, $stored->cred_password);
+        $this->assertSame(self::CLEARTEXT_ENABLE_PASSWORD, $stored->cred_enable_password);
+    }
+}


### PR DESCRIPTION
## Summary

The external REST API returned device credential secrets in cleartext. `GET /api/v1/device-credentials` and `GET /api/v1/device-credentials/{id}` serialised `cred_password` and `cred_enable_password` as decrypted strings to any caller holding a valid API token.

The v1 controller was an empty class body inheriting the internal controller, so it had no masking layer of its own. This restores masking on that boundary.

## Changes

**`Api/v1/DeviceCredentialsController`** now consumes the existing `MaskableCredentials` trait and overrides `index()` and `show()` to mask both secret fields.

- Masking is unconditional. `MASK_DEVICE_CREDENTIALS` governs the device endpoints only and cannot re-enable cleartext secrets on the token authenticated API.
- Masking is applied to the serialised array, not the model, so the mask can never round-trip back through `EncryptStringCast::set()` and reach storage.
- Blank secrets are left as they are, so a caller can still tell that a credential set has no enable password rather than seeing a mask that implies one exists.

**`Api/DeviceCredentialsController`** gains a `protected paginateCredentials()` method extracted from `index()`, so v1 can transform the paginated result without duplicating the query definition. Internal API behaviour is unchanged.

## Behaviour change for API consumers

`cred_password` and `cred_enable_password` on the v1 endpoints now return a masked value (first two characters preserved, remainder starred) instead of the real secret. Stored values are untouched, and config downloads are unaffected. Any integration relying on reading device passwords back out of this API will need to source them elsewhere.

## Tests

New `DeviceCredentialsApiV1MaskingTest` with 10 cases: index and show emit no cleartext, both return masked values, identifying fields still returned, masking holds with `MASK_DEVICE_CREDENTIALS` disabled, blank enable password left untouched, store and update responses do not echo secrets, and stored secrets remain intact behind the mask.

Verified failing before the change and passing after.

```
DeviceCredentialsApiV1MaskingTest      10 passed
Existing v1 + internal creds suites    14 passed
tests/Fasttests/ControllersTests/Api/RestApi/  115 passed
vendor/bin/pint --dirty                passed
composer stan                          No errors
```

## Not covered here

The internal session authenticated endpoints (`/api/device-credentials`, `/api/settings/credentials`) are unchanged and still return cleartext to any authenticated user. That is consistent with Core having no permission system, but Core does ship an Admin/User role that this path ignores. Tracked separately.

Unrelated pre-existing issue noted while testing: a blank secret decodes to boolean `false` rather than `null` through `EncryptStringCast`, and emits a PHP 8.4 `unserialize(): Passing null` deprecation on every read. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
