### PR TITLE
Contain export downloads to the export directory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+rConfig manages credentials for production network infrastructure, so we take reports about this codebase seriously and we would rather hear about a problem early than read about it later.
+
+## Supported versions
+
+Security fixes are issued for the current minor release of rConfig V8 Core. Older releases are not patched, so please upgrade to the latest `core-` tag before reporting an issue you cannot reproduce on a current build.
+
+| Version | Supported |
+| ------- | --------- |
+| 8.2.x   | Yes       |
+| < 8.2   | No        |
+
+## Reporting a vulnerability
+
+Please report privately. Do not open a public GitHub issue, pull request, or discussion for a suspected vulnerability, and please do not post proof of concept details publicly before a fix is available.
+
+Two options:
+
+1. **GitHub Security Advisories (preferred)**: use the "Report a vulnerability" button on the Security tab of this repository. This gives us a private thread with you and a direct route to requesting a CVE.
+2. **Email**: security@rconfig.com
+
+## What to include
+
+The more of this you can provide, the faster we can confirm and fix:
+
+- The version or commit you tested against, and how it was deployed.
+- A description of the issue and the component or file involved.
+- Steps to reproduce, ideally a concrete request or proof of concept.
+- What an attacker gains, and what level of access they need to start with.
+- Any suggested fix, if you have one.
+
+## What to expect from us
+
+- **Acknowledgement within 3 working days** of your report.
+- **An initial assessment within 10 working days**, including whether we have reproduced the issue and our view of the severity.
+- Regular updates while we work on a fix, and notice before we publish.
+- Credit in the release notes and any advisory, under whatever name and link you prefer. Tell us if you would rather stay anonymous.
+
+## Disclosure
+
+We work to coordinated disclosure. Our aim is to ship a fix and publish an advisory within 90 days of a valid report, and sooner for issues that are straightforward or actively exploited. If we need longer, we will explain why rather than let the clock run quietly. We are happy to agree a joint publication date with you.
+
+If you intend to request a CVE, tell us and we will work with you on it, either through GitHub Security Advisories or with your own CNA.
+
+## Scope
+
+In scope: the code in this repository, including the API, the SPA, the download and connection layer, authentication, and the installation scripts we ship.
+
+Out of scope:
+
+- Findings against rConfig Pro. Those belong on the Pro support channel.
+- Issues in third party dependencies with no rConfig specific exploit path. Report those upstream, though we do want to hear if a dependency issue is directly exploitable here.
+- Missing hardening headers, missing rate limits, or scanner output with no demonstrated impact.
+- Anything requiring physical access to the server, or a pre-existing root or database compromise.
+- Social engineering of rConfig staff or users.
+- Behaviour that only affects an installation the reporter controls and that a normal deployment does not expose, for example an intentionally misconfigured `.env` or a self-signed certificate warning.
+
+## Safe harbour
+
+We will not pursue or support legal action against anyone who reports a vulnerability in good faith under this policy, who tests only against their own installation, who avoids accessing or modifying other people's data, and who gives us a reasonable opportunity to fix the issue before disclosing it.
+
+## Deployment hardening
+
+If you are securing an rConfig installation rather than reporting a bug, start with the security guidance in the documentation at https://v8coredocs.rconfig.com and make sure `APP_DEBUG` is `false`, `APP_KEY` is unique to your install, and the `storage` and `.env` paths are not served by your web server.

--- a/app/Http/Controllers/FileDownloadController.php
+++ b/app/Http/Controllers/FileDownloadController.php
@@ -4,7 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Exports\DeviceImportTemplateExport;
 use App\Traits\RespondsWithHttpStatus;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FileDownloadController extends Controller
 {
@@ -18,21 +21,50 @@ class FileDownloadController extends Controller
         return Excel::download(new DeviceImportTemplateExport, 'device_import_template.xlsx');
     }
 
-    public function download_export()
+    /**
+     * Stream a previously generated export file back to the user.
+     *
+     * The requested name is reduced to a bare basename and the resolved path is
+     * checked to sit inside the export directory, so a caller cannot walk out of
+     * it. Every legitimate caller already links to a basename, so this is not a
+     * behaviour change for the UI.
+     */
+    public function download_export(Request $request): BinaryFileResponse|JsonResponse
     {
-        $path = export_path() . $_GET['filename'];
-        if (file_exists($path)) {
-            $logmsg = 'File download: ' . basename($path) . ' was downloaded';
+        $filename = basename((string) $request->query('filename', ''));
+        $path = export_path() . $filename;
+
+        if ($filename !== '' && $this->isContainedInExportPath($path)) {
+            $logmsg = 'File download: ' . $filename . ' was downloaded';
             activityLogIt(__CLASS__, __FUNCTION__, 'info', $logmsg, 'downloader');
 
             return response()->download($path);
         } else {
-            $logmsg = 'FILE DOWNLOAD: ' . basename($path) . ' could not be downloaded';
+            $logmsg = 'FILE DOWNLOAD: ' . $filename . ' could not be downloaded';
             activityLogIt(__CLASS__, __FUNCTION__, 'warn', $logmsg, 'downloader');
 
             $responseArray = ['error' => 404, 'message' => $logmsg];
 
             return \Response::json($responseArray);
         }
+    }
+
+    /**
+     * Confirm the path resolves to a real file physically inside the export directory.
+     *
+     * realpath() collapses any traversal and follows symlinks, so comparing the
+     * resolved value against the resolved export directory catches both.
+     */
+    private function isContainedInExportPath(string $path): bool
+    {
+        $resolvedPath = realpath($path);
+        $resolvedExportPath = realpath(export_path());
+
+        if ($resolvedPath === false || $resolvedExportPath === false) {
+            return false;
+        }
+
+        return is_file($resolvedPath)
+            && str_starts_with($resolvedPath, rtrim($resolvedExportPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
     }
 }

--- a/tests/Fasttests/ControllersTests/FileDownloadControllerTest.php
+++ b/tests/Fasttests/ControllersTests/FileDownloadControllerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Fasttests\ControllersTests;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\File;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+/**
+ * Cover for the /download-export endpoint.
+ *
+ * The filename comes straight off the query string, so the endpoint must only ever
+ * serve files that physically sit in the export directory. A caller must not be able
+ * to walk up out of that directory, reach an absolute path, or follow a symlink out.
+ */
+class FileDownloadControllerTest extends TestCase
+{
+    protected User $user;
+
+    private const EXPORT_FILENAME = 'download_controller_test_export.csv';
+
+    private const EXPORT_CONTENTS = 'id,name' . PHP_EOL . '1,router-01' . PHP_EOL;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->beginTransaction();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+
+        File::ensureDirectoryExists(export_path());
+        File::put(export_path() . self::EXPORT_FILENAME, self::EXPORT_CONTENTS);
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete(export_path() . self::EXPORT_FILENAME);
+
+        $this->rollBackTransaction();
+        parent::tearDown();
+    }
+
+    public function test_it_downloads_a_file_that_lives_in_the_export_directory(): void
+    {
+        $response = $this->get('/download-export?filename=' . self::EXPORT_FILENAME . '&type=export');
+
+        $response->assertStatus(200);
+        $response->assertDownload(self::EXPORT_FILENAME);
+        $this->assertSame(self::EXPORT_CONTENTS, $response->streamedContent());
+    }
+
+    public function test_it_refuses_to_traverse_out_of_the_export_directory_to_the_env_file(): void
+    {
+        $response = $this->get('/download-export?filename=../../../../.env&type=export');
+
+        $this->assertRequestWasRefused($response);
+        $this->assertStringNotContainsString('APP_KEY', $response->getContent());
+        $this->assertStringNotContainsString('DB_PASSWORD', $response->getContent());
+    }
+
+    public function test_it_refuses_a_url_encoded_traversal(): void
+    {
+        $response = $this->get('/download-export?filename=..%2F..%2F..%2F..%2F.env');
+
+        $this->assertRequestWasRefused($response);
+        $this->assertStringNotContainsString('APP_KEY', $response->getContent());
+    }
+
+    public function test_it_refuses_a_deep_traversal_to_a_system_file(): void
+    {
+        $response = $this->get('/download-export?filename=' . str_repeat('../', 12) . 'etc/passwd');
+
+        $this->assertRequestWasRefused($response);
+        $this->assertStringNotContainsString('root:', $response->getContent());
+    }
+
+    /**
+     * The doubled-dot form defeats naive sanitizers that strip '../' once, because
+     * stripping the inner sequence from '....//' leaves a working '../' behind.
+     */
+    public function test_it_refuses_a_doubled_dot_traversal(): void
+    {
+        $response = $this->get('/download-export?filename=....//....//....//....//.env');
+
+        $this->assertRequestWasRefused($response);
+        $this->assertStringNotContainsString('APP_KEY', $response->getContent());
+    }
+
+    public function test_it_refuses_a_nonexistent_export(): void
+    {
+        $response = $this->get('/download-export?filename=no_such_export_file.csv');
+
+        $this->assertRequestWasRefused($response);
+    }
+
+    public function test_it_refuses_an_absolute_path(): void
+    {
+        $response = $this->get('/download-export?filename=/etc/passwd');
+
+        $this->assertRequestWasRefused($response);
+        $this->assertStringNotContainsString('root:', $response->getContent());
+    }
+
+    public function test_it_refuses_a_path_that_reaches_a_sibling_storage_directory(): void
+    {
+        $response = $this->get('/download-export?filename=../logs/laravel.log');
+
+        $this->assertRequestWasRefused($response);
+    }
+
+    public function test_it_refuses_a_nested_path_below_the_export_directory(): void
+    {
+        $nestedDirectory = export_path() . 'nested_download_test';
+        File::ensureDirectoryExists($nestedDirectory);
+        File::put($nestedDirectory . '/nested.csv', 'nested');
+
+        $response = $this->get('/download-export?filename=nested_download_test/nested.csv');
+
+        $this->assertRequestWasRefused($response);
+
+        File::deleteDirectory($nestedDirectory);
+    }
+
+    public function test_it_refuses_a_symlink_that_points_out_of_the_export_directory(): void
+    {
+        $target = base_path('.env');
+        if (! File::exists($target)) {
+            $this->markTestSkipped('No .env file present to link against.');
+        }
+
+        $link = export_path() . 'download_controller_test_link';
+        @symlink($target, $link);
+        if (! is_link($link)) {
+            $this->markTestSkipped('Unable to create a symlink in the export directory.');
+        }
+
+        $response = $this->get('/download-export?filename=download_controller_test_link');
+
+        $this->assertRequestWasRefused($response);
+        $this->assertStringNotContainsString('APP_KEY', $response->getContent());
+
+        unlink($link);
+    }
+
+    public function test_it_refuses_a_missing_or_empty_filename(): void
+    {
+        $this->assertRequestWasRefused($this->get('/download-export'));
+        $this->assertRequestWasRefused($this->get('/download-export?filename='));
+        $this->assertRequestWasRefused($this->get('/download-export?filename=..'));
+    }
+
+    public function test_it_requires_an_authenticated_user(): void
+    {
+        Auth::logout();
+
+        $response = $this->get('/download-export?filename=' . self::EXPORT_FILENAME);
+
+        $response->assertRedirect('/login');
+    }
+
+    /**
+     * The endpoint answers a rejected download with the legacy 200 plus error body shape.
+     * Assert on the body rather than the status so the check stays meaningful either way.
+     */
+    private function assertRequestWasRefused(TestResponse $response): void
+    {
+        $this->assertNotSame(
+            'attachment',
+            substr((string) $response->headers->get('content-disposition'), 0, 10),
+            'Endpoint served a file it should have refused.'
+        );
+
+        if ($response->getStatusCode() === 200) {
+            $response->assertJsonPath('error', 404);
+        }
+    }
+}


### PR DESCRIPTION
## What

`FileDownloadController::download_export()` built its file path by concatenating the raw `filename` query parameter onto `export_path()`, with no sanitization. A request could walk out of the export directory and read any file readable by the web user.

## Fix

- Switch the method off `$_GET` onto the injected `Request`.
- Reduce the requested name through `basename()`.
- Confirm the resolved path is a real file inside `export_path()` before serving it. `realpath()` collapses traversal sequences and follows symlinks, so both escape routes are closed independently.

Every existing caller (`ExportController`, `DeviceInventoryExporter`) already links to a bare basename, so there is no behaviour change for the UI. The legacy rejection response shape (HTTP 200 with an `{"error": 404}` body) is kept as-is, since the SPA may branch on it.

## Tests

12 cases in `tests/Fasttests/ControllersTests/FileDownloadControllerTest.php`: happy path, parent traversal, URL-encoded traversal, doubled-dot (`....//`) form, deep traversal to a system file, absolute path, sibling storage directory, nested path below exports, symlink pointing outside, nonexistent export, empty and missing filename, and unauthenticated access.

Validated by re-introducing the flaw in the new code shape and confirming 5 of the 12 fail. `ExportControllerTest` still passes. Pint and PHPStan clean.

## Also

Adds `SECURITY.md`, so reports have a private channel. Note two items for review: it lists `security@rconfig.com`, and it points at GitHub Security Advisories as the preferred route, which needs private vulnerability reporting enabled in repo settings.

No front end changes, so no `public/build` rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)