### PR TITLE
Take the superseded template filename from the record, not the request

### DIFF
--- a/app/Http/Controllers/Api/TemplateController.php
+++ b/app/Http/Controllers/Api/TemplateController.php
@@ -73,18 +73,27 @@ class TemplateController extends ApiBaseController
         return response()->json($result);
     }
 
+    /**
+     * Replace a template, removing the file the record currently points at.
+     *
+     * The name of the outgoing file is taken from the stored record rather than
+     * from the request, so a caller cannot nominate a file outside the templates
+     * directory for deletion. It is reduced to a basename as well, so a record
+     * written by some other path cannot escape either.
+     */
     public function update($id, StoreTemplateRequest $request)
     {
+        $template = Template::findOrFail($id);
 
-        $oldFilename = $request->fileName;
+        $storage_dir = storage_path() . '/app/rconfig/templates/';
 
-        if (File::exists(storage_path() . '/app/rconfig/templates/' . $oldFilename)) {
-            File::delete(storage_path() . '/app/rconfig/templates/' . $oldFilename);
+        $oldFilename = basename((string) $template->fileName);
+        if ($oldFilename !== '' && File::exists($storage_dir . $oldFilename)) {
+            File::delete($storage_dir . $oldFilename);
         }
 
         $fileName = $this->sanitizeFileName($request['templateName']);
 
-        $storage_dir = storage_path() . '/app/rconfig/templates/';
         $filePath = $storage_dir . $fileName;
 
         if (File::exists($filePath)) {

--- a/app/Http/Requests/StoreTemplateRequest.php
+++ b/app/Http/Requests/StoreTemplateRequest.php
@@ -16,10 +16,18 @@ class StoreTemplateRequest extends FormRequest
     {
         $rules = [];
 
+        /**
+         * fileName is derived server side from templateName, so a caller never needs
+         * to send a path. Reject traversal sequences outright rather than trusting
+         * every downstream consumer to sanitize.
+         */
+        $fileNameRules = ['nullable', 'string', 'max:255', 'not_regex:/\.\./'];
+
         if ($this->getMethod() == 'POST') {
             $rules = [
                 'templateName' => 'required|max:255',
                 'code' => 'required',
+                'fileName' => $fileNameRules,
             ];
         }
 
@@ -27,6 +35,7 @@ class StoreTemplateRequest extends FormRequest
             $rules = [
                 'templateName' => 'required|max:255',
                 'code' => 'required',
+                'fileName' => $fileNameRules,
             ];
         }
 

--- a/tests/Fasttests/ControllersTests/Api/TemplateUpdateFilePathTest.php
+++ b/tests/Fasttests/ControllersTests/Api/TemplateUpdateFilePathTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Fasttests\ControllersTests\Api;
+
+use App\Models\RestApiToken;
+use App\Models\Template;
+use App\Models\User;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+/**
+ * Cover for the file handling in TemplateController::update().
+ *
+ * Updating a template deletes the file the record currently points at. That name must
+ * come from the stored record, never from the request, otherwise a caller can nominate
+ * any file on disk for deletion. The same method is inherited by the token authenticated
+ * v1 API, so both routes are exercised here.
+ */
+class TemplateUpdateFilePathTest extends TestCase
+{
+    protected User $user;
+    private string $templatesDir;
+    private string $canaryPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->beginTransaction();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+
+        $this->templatesDir = storage_path() . '/app/rconfig/templates/';
+        $this->canaryPath = storage_path() . '/app/rconfig/template_update_canary.txt';
+
+        File::ensureDirectoryExists($this->templatesDir);
+        File::put($this->canaryPath, 'this file lives outside the templates directory');
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->canaryPath);
+
+        foreach (File::glob($this->templatesDir . 'template_update_test*') as $leftover) {
+            File::delete($leftover);
+        }
+
+        $this->rollBackTransaction();
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function payload(string $fileName, string $templateName = 'template_update_test_new'): array
+    {
+        return [
+            'templateName' => $templateName,
+            'code' => "main:\n  name: probe\n  desc: probe\n",
+            'fileName' => $fileName,
+        ];
+    }
+
+    private function makeTemplateWithFile(): Template
+    {
+        $existing = 'template_update_test_original.yml';
+        File::put($this->templatesDir . $existing, 'main:');
+
+        return Template::factory()->create([
+            'fileName' => '/app/rconfig/templates/' . $existing,
+            'templateName' => 'template_update_test_original',
+        ]);
+    }
+
+    public function test_it_does_not_delete_a_file_outside_the_templates_directory(): void
+    {
+        $template = $this->makeTemplateWithFile();
+
+        $this->patchJson('/api/templates/' . $template->id, $this->payload('../template_update_canary.txt'));
+
+        $this->assertTrue(
+            File::exists($this->canaryPath),
+            'A file outside the templates directory was deleted through the fileName parameter.'
+        );
+    }
+
+    public function test_it_does_not_delete_a_file_via_a_deep_traversal(): void
+    {
+        $template = $this->makeTemplateWithFile();
+
+        $this->patchJson(
+            '/api/templates/' . $template->id,
+            $this->payload('../../../../storage/app/rconfig/template_update_canary.txt')
+        );
+
+        $this->assertTrue(File::exists($this->canaryPath));
+    }
+
+    public function test_it_rejects_a_filename_containing_a_traversal_sequence(): void
+    {
+        $template = $this->makeTemplateWithFile();
+
+        $response = $this->patchJson('/api/templates/' . $template->id, $this->payload('../template_update_canary.txt'));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('fileName');
+    }
+
+    public function test_the_v1_api_is_protected_by_the_same_check(): void
+    {
+        $token = RestApiToken::factory()->create();
+        $template = $this->makeTemplateWithFile();
+
+        $this->patchJson(
+            '/api/v1/templates/' . $template->id,
+            $this->payload('../template_update_canary.txt'),
+            ['apitoken' => $token->api_token]
+        );
+
+        $this->assertTrue(
+            File::exists($this->canaryPath),
+            'The v1 API allowed a file outside the templates directory to be deleted.'
+        );
+    }
+
+    public function test_it_still_replaces_the_previous_template_file_on_a_normal_update(): void
+    {
+        $template = $this->makeTemplateWithFile();
+        $originalPath = $this->templatesDir . 'template_update_test_original.yml';
+
+        $response = $this->patchJson(
+            '/api/templates/' . $template->id,
+            $this->payload('template_update_test_original.yml', 'template_update_test_renamed')
+        );
+
+        $response->assertSuccessful();
+        $this->assertFalse(File::exists($originalPath), 'The superseded template file was left behind.');
+        $this->assertTrue(
+            File::exists($this->templatesDir . 'template_update_test_renamed.yml'),
+            'The new template file was not written.'
+        );
+        $this->assertTrue(File::exists($this->canaryPath));
+    }
+
+    public function test_it_handles_a_record_with_no_stored_filename(): void
+    {
+        $template = Template::factory()->create([
+            'fileName' => '',
+            'templateName' => 'template_update_test_empty',
+        ]);
+
+        $response = $this->patchJson(
+            '/api/templates/' . $template->id,
+            $this->payload('', 'template_update_test_empty_renamed')
+        );
+
+        $response->assertSuccessful();
+        $this->assertTrue(File::exists($this->canaryPath));
+    }
+}


### PR DESCRIPTION
## What

`TemplateController::update()` deleted the outgoing template file using the `fileName` value from the request body:

```php
$oldFilename = $request->fileName;
if (File::exists(storage_path() . '/app/rconfig/templates/' . $oldFilename)) {
    File::delete(storage_path() . '/app/rconfig/templates/' . $oldFilename);
}
```

`fileName` was not validated in `StoreTemplateRequest` and never passed through `sanitizeFileName()`, unlike every other name in this controller. Any authenticated user could nominate any file the web user can write for deletion. `Api\v1\TemplateController` inherits the method, so `PATCH /api/v1/templates/{id}` reached it with an API token as well.

Confirmed at runtime before fixing: a PATCH with `fileName: "../canary.txt"` returned HTTP 200 and removed a file outside the templates directory.

## Fix

- Take the outgoing filename from the persisted `Template` record rather than the request, and reduce it to a `basename()` so a record written by any other path cannot escape either.
- Reject traversal sequences in `fileName` at the form request, as a second layer for any future consumer of that field.

The write path already resolved through `sanitizeFileName()` and is unchanged. Normal rename-and-replace behaviour is preserved and covered by a test.

## Tests

6 cases in `tests/Fasttests/ControllersTests/Api/TemplateUpdateFilePathTest.php`: parent traversal, deep traversal, validation rejection, the v1 API route, normal update still replacing the previous file, and a record with an empty stored filename.

Verified the cover is real by removing the defences and re-running:

- Both removed: 4 of 6 fail.
- Validation removed, controller fix alone: all three canary tests still pass, so the controller fix stands on its own rather than being masked by validation.

Existing `TemplatesControllerTest` (12 tests) passes unchanged. Pint and PHPStan clean.

No front end changes, so no `public/build` rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)