### PR TITLE
Fix the storage seeding CI job so it reaches the code it tests

### DIFF
--- a/.github/workflows/docker-storage-seeding.yml
+++ b/.github/workflows/docker-storage-seeding.yml
@@ -13,6 +13,8 @@ on:
       - 'docker/**'
       - 'storage/app/rconfig/**'
       - '.github/workflows/docker-storage-seeding.yml'
+  # So the job can be run against a branch without opening a pull request.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -49,6 +51,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # .dockerignore excludes .env.* so .env.example is not in the image, and
+      # the entrypoint copies from it only when .env is absent. The published
+      # compose always bind mounts .env from the host, so that path never runs
+      # in a real deployment. Mirror the published arrangement here, or the
+      # container dies on the missing example file before it reaches the seed.
+      #
+      # Deliberately not named .env: compose treats a file of that name in the
+      # project directory as its own variable interpolation source.
+      - name: Provide the application env file
+        run: cp .env.example app.env
+
       - name: Write compose file
         run: |
           set -euo pipefail
@@ -66,6 +79,7 @@ jobs:
                 - REDIS_PORT=6379
               volumes:
                 - ${BIND_DIR:?}:/var/www/html/rconfig/storage
+                - ./app.env:/var/www/html/rconfig/.env
               depends_on:
                 db:
                   condition: service_healthy
@@ -94,6 +108,18 @@ jobs:
               echo "Storage seeded."
               exit 0
             fi
+
+            # A container that has already died will never seed anything, so
+            # stop rather than sitting out the full timeout. The entrypoint
+            # exits non-zero by design when it cannot write to storage, and
+            # that is a failure worth reporting immediately.
+            cid="$(docker compose -f compose.ci.yml ps -q app || true)"
+            if [ -z "${cid}" ] || [ "$(docker inspect -f '{{.State.Status}}' "${cid}" 2>/dev/null || echo gone)" != "running" ]; then
+              echo "::error::The app container is no longer running, so storage was never seeded."
+              docker compose -f compose.ci.yml logs app
+              exit 1
+            fi
+
             sleep 5
           done
           echo "::error::Storage was not seeded within the timeout."


### PR DESCRIPTION
### Summary
The `Bind-mounted storage is seeded` job added in #358 failed on its first real run. It never reached the seeding code it exists to test, so the #357 fix is currently unverified end to end.

### What went wrong
```
📝 Creating .env file from example...
cp: cannot stat '/var/www/html/rconfig/.env.example': No such file or directory
```

`.dockerignore` excludes `.env.*`, so `.env.example` is not in the image. The entrypoint copies from it only when `.env` is absent, and the published `docker-compose.yml` always bind mounts `.env` from the host, so that branch never runs in a real deployment. The CI compose omitted that mount, so the container died on the missing file before it reached the storage seeding block.

The job was testing an arrangement that does not ship.

### Changes
- CI compose mirrors the published one and bind mounts an env file. Named `app.env` rather than `.env`, because compose treats a file called `.env` in the project directory as its own variable interpolation source.
- The wait loop stops as soon as the app container is no longer running, instead of sitting out its full five minute timeout against a dead container and reporting a misleading "not seeded within the timeout". The failed run burned 9m28s this way.
- `workflow_dispatch` added so the job can be run against a branch without opening a pull request.

### Note, not fixed here
The entrypoint's `.env` bootstrap is dead code in the image: `.env.example` can never be present, so `docker run` without an `.env` bind mount always dies with the confusing `cp: cannot stat` above. Shipping `.env.example` would be the wrong fix, since it would let a container come up with a throwaway `APP_KEY` that is lost on recreation, which is presumably why the compose file bind mounts `.env` in the first place. The better fix is an explicit error telling the user to mount `.env`. Raised separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)