### PR TITLE
closes RCO-1298 Core parity: normalise template switches and protocol…

### DIFF
--- a/app/Http/Controllers/Connections/MainConnectionManager.php
+++ b/app/Http/Controllers/Connections/MainConnectionManager.php
@@ -22,16 +22,20 @@ class MainConnectionManager
     {
         $this->getAllConnectionParamsArray();
 
-        if ($this->deviceParamsObject->connect['protocol'] == 'telnet') {
+        // TemplateNormaliser has already lowercased and trimmed this, so a compare
+        // against the lowercase literals is all that is needed here.
+        $protocol = $this->deviceParamsObject->connect['protocol'] ?? null;
+
+        if ($protocol === 'telnet') {
             $this->telnetConnection = new TelnetConnectionManager($this->deviceParamsObject, $this->debug);
 
             return $this->telnetConnection->telnetConnectionAndOutput();
-        } elseif ($this->deviceParamsObject->connect['protocol'] == 'ssh') {
+        } elseif ($protocol === 'ssh') {
             $this->sshConnection = new SSHConnectionManager($this->deviceParamsObject, $this->debug);
 
             return $this->sshConnection->SshConnectionAndOutput();
         } else {
-            throw new \Exception('Error Processing ' . __CLASS__ . ' - ' . __FUNCTION__ . ' Request. Your rConfig template file could be invalid.', 1);
+            throw new \Exception('Error Processing ' . __CLASS__ . ' - ' . __FUNCTION__ . ' Request. Your rConfig template file carries connect.protocol "' . (is_scalar($protocol) ? $protocol : gettype($protocol)) . '", which is not one of ssh or telnet.', 1);
         }
     }
 

--- a/app/Http/Controllers/Connections/Params/ConnectionParams.php
+++ b/app/Http/Controllers/Connections/Params/ConnectionParams.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Connections\Params;
 
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -23,7 +24,7 @@ class ConnectionParams
     {
         $templateArray = $this->getTemplateArray();
 
-        return $this->templateToArray($templateArray['code']);
+        return (new TemplateNormaliser(Log::channel()))->normalise($this->templateToArray($templateArray['code']));
     }
 
     private function getTemplateArray()

--- a/app/Http/Controllers/Connections/Params/TemplateNormaliser.php
+++ b/app/Http/Controllers/Connections/Params/TemplateNormaliser.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Connections\Params;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Canonicalises template values before anything downstream consumes them.
+ *
+ * Symfony's YAML parser types `on`, `off`, `yes` and `no` as plain strings but types
+ * `true` and `false` as real booleans, so a template author writing the intuitive
+ * thing produced a value no consumer recognised. The consumers then disagreed with
+ * each other: `auth.enable` was compared loosely and happened to survive the mistake,
+ * `config.paging` was compared strictly and silently stopped disabling the pager. Same
+ * mistake, opposite outcomes, nothing logged either way.
+ *
+ * Every switch is settled on 'on' or 'off' here, and `connect.protocol` is lowercased,
+ * so the consumers compare one canonical form.
+ */
+class TemplateNormaliser
+{
+    /**
+     * Switch keys per template section, canonicalised to 'on' or 'off'.
+     *
+     * @var array<string, list<string>>
+     */
+    private const BOOLEAN_KEYS = [
+        'connect' => ['isNonInteractiveMode'],
+        'auth' => ['enable', 'enableUsername', 'hpAnyKeyStatus', 'sshInteractive'],
+        'config' => ['paging', 'isMikrotik'],
+        'options' => ['AnsiHost'],
+        'vt100' => ['hasSplashScreen', 'hasSplashScreenEnterKey'],
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const TRUTHY = ['on', 'yes', 'true', 'y', '1', 'enable', 'enabled'];
+
+    /**
+     * @var list<string>
+     */
+    private const FALSY = ['off', 'no', 'false', 'n', '0', '', 'disable', 'disabled'];
+
+    public function __construct(private LoggerInterface $logger) {}
+
+    /**
+     * @param  array<string, mixed>|null  $template
+     * @return array<string, mixed>|null
+     */
+    public function normalise(?array $template): ?array
+    {
+        if ($template === null) {
+            return null;
+        }
+
+        $template = $this->normaliseProtocol($template);
+
+        foreach (self::BOOLEAN_KEYS as $section => $keys) {
+            if (! isset($template[$section]) || ! is_array($template[$section])) {
+                continue;
+            }
+
+            foreach ($keys as $key) {
+                if (! array_key_exists($key, $template[$section])) {
+                    continue;
+                }
+
+                $template[$section][$key] = $this->toSwitch($template[$section][$key], $section . '.' . $key);
+            }
+        }
+
+        return $template;
+    }
+
+    /**
+     * The dispatcher compares against lowercase literals, so `protocol: SSH` used to
+     * fall through to the generic "your template file could be invalid" exception with
+     * no pointer at the capital letters. Lowercase and trim once, here.
+     *
+     * @param  array<string, mixed>  $template
+     * @return array<string, mixed>
+     */
+    private function normaliseProtocol(array $template): array
+    {
+        if (! isset($template['connect']) || ! is_array($template['connect'])) {
+            return $template;
+        }
+
+        if (! array_key_exists('protocol', $template['connect']) || ! is_string($template['connect']['protocol'])) {
+            return $template;
+        }
+
+        $raw = $template['connect']['protocol'];
+        $protocol = strtolower(trim($raw));
+
+        if ($protocol !== $raw) {
+            $this->logger->info('Template value normalised', [
+                'key' => 'connect.protocol',
+                'from' => $raw,
+                'to' => $protocol,
+            ]);
+        }
+
+        $template['connect']['protocol'] = $protocol;
+
+        return $template;
+    }
+
+    /**
+     * A missing value stays missing, since the consumers treat null as "not set".
+     * A value nobody recognises is left exactly as written and logged, so it keeps its
+     * current off-by-default behaviour rather than being guessed at.
+     */
+    private function toSwitch(mixed $value, string $path): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $this->logNormalised($path, $value ? 'true' : 'false', $value ? 'on' : 'off');
+        }
+
+        if (! is_scalar($value)) {
+            return $this->logUnrecognised($path, $value);
+        }
+
+        $candidate = strtolower(trim((string) $value));
+
+        if (in_array($candidate, self::TRUTHY, true)) {
+            return $candidate === 'on' ? 'on' : $this->logNormalised($path, (string) $value, 'on');
+        }
+
+        if (in_array($candidate, self::FALSY, true)) {
+            return $candidate === 'off' ? 'off' : $this->logNormalised($path, (string) $value, 'off');
+        }
+
+        return $this->logUnrecognised($path, $value);
+    }
+
+    private function logNormalised(string $path, string $from, string $to): string
+    {
+        $this->logger->info('Template value normalised', [
+            'key' => $path,
+            'from' => $from,
+            'to' => $to,
+        ]);
+
+        return $to;
+    }
+
+    private function logUnrecognised(string $path, mixed $value): mixed
+    {
+        $this->logger->warning('Template value is not a recognised on/off switch and was left as written', [
+            'key' => $path,
+            'value' => is_scalar($value) ? (string) $value : gettype($value),
+        ]);
+
+        return $value;
+    }
+}

--- a/app/Http/Controllers/Connections/SSH/Login.php
+++ b/app/Http/Controllers/Connections/SSH/Login.php
@@ -38,7 +38,7 @@ class Login
 
         $this->handleSplashScreen();
 
-        if ($this->connectionObj->enable == 'on') {
+        if ($this->connectionObj->enable === 'on') {
             $this->enableModeLogin();
         } else {
             $this->sendPagingCommand();
@@ -106,7 +106,7 @@ class Login
 
     private function shouldUseInteractiveLogin(): bool
     {
-        return $this->connectionObj->sshInteractive === 'on' || $this->connectionObj->sshInteractive === 'yes';
+        return $this->connectionObj->sshInteractive === 'on';
     }
 
     private function handleSplashScreen(): void
@@ -116,7 +116,7 @@ class Login
             return;
         }
 
-        if (isset($this->connectionObj->hasSplashScreenEnterKey) && $this->connectionObj->hasSplashScreenEnterKey == 'on') {
+        if (isset($this->connectionObj->hasSplashScreenEnterKey) && $this->connectionObj->hasSplashScreenEnterKey === 'on') {
             // some devices require an enter key to be sent to get past the splash screen
             $this->connectionObj->connection->write("\n");
             sleep(1);

--- a/app/Http/Controllers/Connections/SSH/SendCommand.php
+++ b/app/Http/Controllers/Connections/SSH/SendCommand.php
@@ -22,7 +22,7 @@ class SendCommand
     public function sendShowCommand($command)
     {
 
-        if ($this->connectionObj->sshPrivKey && $this->connectionObj->isNonInteractiveMode) {
+        if ($this->connectionObj->sshPrivKey && $this->connectionObj->isNonInteractiveMode === 'on') {
             return $this->execShowCommand($command);
         }
 
@@ -30,15 +30,15 @@ class SendCommand
             return $this->ansiShowCommand($command);
         }
 
-        if ($this->connectionObj->isNonInteractiveMode) {
+        if ($this->connectionObj->isNonInteractiveMode === 'on') {
             return $this->execShowCommand($command);
         }
 
-        if ($this->connectionObj->AnsiHost === 'yes') {
+        if ($this->connectionObj->AnsiHost === 'on') {
             return $this->ansiShowCommand($command);
         }
 
-        if ($this->connectionObj->isMikrotik === 'yes') {
+        if ($this->connectionObj->isMikrotik === 'on') {
             // need to remove prompt. Mikrotik does not respond well to having a prompt configured. See the mikrotik function in the console rconfig:test command
             $this->connectionObj->devicePrompt = '';
             $this->data = $this->connectionObj->connection->read('~' . $this->connectionObj->devicePrompt . '~', SSH2::READ_REGEX);

--- a/app/Http/Controllers/Connections/Telnet/Login.php
+++ b/app/Http/Controllers/Connections/Telnet/Login.php
@@ -21,7 +21,7 @@ class Login
     public function login()
     {
 
-        if (isset($this->connectionObj->hasSplashScreen) && $this->connectionObj->hasSplashScreen == 'on') {
+        if (isset($this->connectionObj->hasSplashScreen) && $this->connectionObj->hasSplashScreen === 'on') {
             // avaya login
             $this->read->readTo($this->connectionObj->splashScreenReadToText);
             $this->send->sendControlCode($this->connectionObj->splashScreenSendControlCode);
@@ -35,7 +35,7 @@ class Login
         $this->read->readTo($this->connectionObj->passwordPrompt);
         $this->send->sendString($this->connectionObj->password);
 
-        if ($this->connectionObj->enable == 'on') {
+        if ($this->connectionObj->enable === 'on') {
             $devicePromptValid = $this->enableModeLogin();
         } else {
             $devicePromptValid = $this->read->readTo($this->connectionObj->devicePrompt);

--- a/tests/Unit/Connections/SendCommandSwitchRoutingTest.php
+++ b/tests/Unit/Connections/SendCommandSwitchRoutingTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Unit\Connections;
+
+use App\Http\Controllers\Connections\SSH\SendCommand as SshSendCommand;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The SSH send path picks between exec, ANSI and standard reads from template switches.
+ * `isNonInteractiveMode` used to be read as a bare truthy value, so the string 'off' took
+ * the exec branch, and `AnsiHost` / `isMikrotik` were compared against 'yes' while every
+ * other switch was compared against 'on'. TemplateNormaliser settles all of them on
+ * 'on' / 'off', so these assert the branch each canonical value now takes.
+ *
+ * SendCommand holds a live socket, so it is built without its constructor and driven
+ * through recording doubles.
+ */
+class SendCommandSwitchRoutingTest extends TestCase
+{
+    /**
+     * @param  array<string, mixed>  $switches
+     * @return list<string>
+     */
+    private function trace(array $switches): array
+    {
+        $trace = [];
+
+        $connection = new class($trace)
+        {
+            /**
+             * @param  list<string>  $trace
+             */
+            public function __construct(private array &$trace) {}
+
+            public function read(...$arguments): string
+            {
+                $this->trace[] = 'connection.read';
+
+                return "show run\r\nhostname r1\r\nr1#";
+            }
+        };
+
+        $send = new class($trace)
+        {
+            /**
+             * @param  list<string>  $trace
+             */
+            public function __construct(private array &$trace) {}
+
+            public function sendString($command): void
+            {
+                $this->trace[] = 'send.sendString';
+            }
+
+            public function sendStringExec($command): string
+            {
+                $this->trace[] = 'send.sendStringExec';
+
+                return "hostname r1\r\n";
+            }
+        };
+
+        $connectionObj = (object) array_merge([
+            'connection' => $connection,
+            'devicePrompt' => 'r1#',
+            'sshPrivKey' => null,
+            'isNonInteractiveMode' => 'off',
+            'AnsiHost' => 'off',
+            'isMikrotik' => 'off',
+            'hpAnyKeyStatus' => 'off',
+            'setTerminalDimensions' => null,
+        ], $switches);
+
+        $reflection = new ReflectionClass(SshSendCommand::class);
+        $sendCommand = $reflection->newInstanceWithoutConstructor();
+        $reflection->getProperty('connectionObj')->setValue($sendCommand, $connectionObj);
+        $reflection->getProperty('send')->setValue($sendCommand, $send);
+
+        $sendCommand->sendShowCommand('show run');
+
+        return $trace;
+    }
+
+    public function test_switches_all_off_take_the_standard_read(): void
+    {
+        $this->assertSame(['send.sendString', 'connection.read'], $this->trace([]));
+    }
+
+    public function test_non_interactive_mode_off_no_longer_takes_the_exec_branch(): void
+    {
+        $this->assertNotContains('send.sendStringExec', $this->trace(['isNonInteractiveMode' => 'off']));
+    }
+
+    public function test_non_interactive_mode_on_takes_the_exec_branch(): void
+    {
+        $this->assertContains('send.sendStringExec', $this->trace(['isNonInteractiveMode' => 'on']));
+    }
+
+    public function test_ansi_host_on_takes_the_ansi_branch(): void
+    {
+        $this->assertSame(
+            ['connection.read', 'send.sendString', 'connection.read'],
+            $this->trace(['AnsiHost' => 'on'])
+        );
+    }
+
+    public function test_ansi_host_off_does_not_take_the_ansi_branch(): void
+    {
+        $this->assertSame(['send.sendString', 'connection.read'], $this->trace(['AnsiHost' => 'off']));
+    }
+
+    public function test_mikrotik_on_reads_once_before_the_standard_read(): void
+    {
+        $this->assertSame(
+            ['connection.read', 'send.sendString', 'connection.read'],
+            $this->trace(['isMikrotik' => 'on'])
+        );
+    }
+
+    public function test_mikrotik_off_does_not_read_first(): void
+    {
+        $this->assertSame(['send.sendString', 'connection.read'], $this->trace(['isMikrotik' => 'off']));
+    }
+}

--- a/tests/Unit/Connections/TemplateNormaliserTest.php
+++ b/tests/Unit/Connections/TemplateNormaliserTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Unit\Connections;
+
+use App\Http\Controllers\Connections\Params\TemplateNormaliser;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Template switches used to be consumed exactly as the YAML parser typed them, and the
+ * parser types `on` / `off` / `yes` / `no` as strings but `true` / `false` as booleans.
+ * Consumers then compared the raw value each in their own way, so the same authoring
+ * mistake activated enable mode and silently failed to disable paging. Everything is
+ * settled on 'on' / 'off' here instead.
+ */
+class TemplateNormaliserTest extends TestCase
+{
+    private TemplateNormaliser $normaliser;
+
+    /**
+     * @var list<array{level: mixed, message: string|\Stringable, context: array<string, mixed>}>
+     */
+    private array $logged = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logged = [];
+
+        $logger = new class($this->logged) extends AbstractLogger
+        {
+            /**
+             * @param  list<array{level: mixed, message: string|\Stringable, context: array<string, mixed>}>  $logged
+             */
+            public function __construct(private array &$logged) {}
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->logged[] = ['level' => $level, 'message' => $message, 'context' => $context];
+            }
+        };
+
+        $this->normaliser = new TemplateNormaliser($logger);
+    }
+
+    /**
+     * @return list<array{level: mixed, message: string|\Stringable, context: array<string, mixed>}>
+     */
+    private function loggedAt(string $level): array
+    {
+        return array_values(array_filter($this->logged, fn (array $entry): bool => $entry['level'] === $level));
+    }
+
+    /**
+     * @param  array<string, mixed>  $template
+     * @return array<string, mixed>
+     */
+    private function normalise(array $template): array
+    {
+        return $this->normaliser->normalise($template) ?? [];
+    }
+
+    public function test_yaml_types_on_and_true_differently_which_is_the_whole_problem(): void
+    {
+        $parsed = Yaml::parse("paging: on\nenable: true\nsplash: yes\nquiet: off\n");
+
+        $this->assertSame('on', $parsed['paging']);
+        $this->assertTrue($parsed['enable']);
+        $this->assertSame('yes', $parsed['splash']);
+        $this->assertSame('off', $parsed['quiet']);
+    }
+
+    public function test_boolean_true_and_false_become_on_and_off(): void
+    {
+        $result = $this->normalise([
+            'auth' => ['enable' => true],
+            'config' => ['paging' => false],
+        ]);
+
+        $this->assertSame('on', $result['auth']['enable']);
+        $this->assertSame('off', $result['config']['paging']);
+    }
+
+    public function test_yes_and_no_become_on_and_off(): void
+    {
+        $result = $this->normalise([
+            'options' => ['AnsiHost' => 'yes'],
+            'config' => ['isMikrotik' => 'no'],
+        ]);
+
+        $this->assertSame('on', $result['options']['AnsiHost']);
+        $this->assertSame('off', $result['config']['isMikrotik']);
+    }
+
+    public function test_canonical_values_are_left_alone(): void
+    {
+        $result = $this->normalise([
+            'auth' => ['enable' => 'on', 'hpAnyKeyStatus' => 'off'],
+        ]);
+
+        $this->assertSame('on', $result['auth']['enable']);
+        $this->assertSame('off', $result['auth']['hpAnyKeyStatus']);
+    }
+
+    public function test_casing_and_surrounding_whitespace_are_tolerated(): void
+    {
+        $result = $this->normalise([
+            'auth' => ['enable' => ' ON ', 'sshInteractive' => 'TRUE'],
+            'vt100' => ['hasSplashScreen' => 'No'],
+        ]);
+
+        $this->assertSame('on', $result['auth']['enable']);
+        $this->assertSame('on', $result['auth']['sshInteractive']);
+        $this->assertSame('off', $result['vt100']['hasSplashScreen']);
+    }
+
+    public function test_an_empty_value_reads_as_off(): void
+    {
+        $result = $this->normalise(['config' => ['paging' => '']]);
+
+        $this->assertSame('off', $result['config']['paging']);
+    }
+
+    public function test_a_null_value_stays_null(): void
+    {
+        $result = $this->normalise(['config' => ['paging' => null]]);
+
+        $this->assertNull($result['config']['paging']);
+    }
+
+    public function test_absent_keys_and_absent_sections_stay_absent(): void
+    {
+        $result = $this->normalise([
+            'auth' => ['enable' => 'on'],
+        ]);
+
+        $this->assertArrayNotHasKey('paging', $result['auth']);
+        $this->assertArrayNotHasKey('config', $result);
+        $this->assertArrayNotHasKey('vt100', $result);
+    }
+
+    public function test_keys_that_are_not_switches_are_untouched(): void
+    {
+        $result = $this->normalise([
+            'config' => ['paging' => 'yes', 'pagingCmd' => 'terminal length 0', 'exitCmd' => 'no paging'],
+            'auth' => ['username' => 'Username:', 'enable' => 'off'],
+        ]);
+
+        $this->assertSame('terminal length 0', $result['config']['pagingCmd']);
+        $this->assertSame('no paging', $result['config']['exitCmd']);
+        $this->assertSame('Username:', $result['auth']['username']);
+    }
+
+    public function test_an_unrecognised_switch_is_left_as_written_and_logged(): void
+    {
+        $result = $this->normalise(['config' => ['paging' => 'sometimes']]);
+
+        $this->assertSame('sometimes', $result['config']['paging']);
+
+        $warnings = $this->loggedAt('warning');
+        $this->assertCount(1, $warnings);
+        $this->assertSame('config.paging', $warnings[0]['context']['key']);
+        $this->assertSame('sometimes', $warnings[0]['context']['value']);
+    }
+
+    public function test_a_value_that_had_to_be_rewritten_is_logged(): void
+    {
+        $this->normalise([
+            'connect' => ['protocol' => 'SSH'],
+            'auth' => ['enable' => true],
+            'config' => ['paging' => 'off'],
+        ]);
+
+        $keys = array_column(array_column($this->loggedAt('info'), 'context'), 'key');
+
+        $this->assertContains('connect.protocol', $keys);
+        $this->assertContains('auth.enable', $keys);
+        $this->assertNotContains('config.paging', $keys, 'A value already in canonical form should not be logged.');
+    }
+
+    public function test_protocol_is_lowercased_and_trimmed(): void
+    {
+        $result = $this->normalise(['connect' => ['protocol' => ' SSH ']]);
+
+        $this->assertSame('ssh', $result['connect']['protocol']);
+    }
+
+    public function test_protocol_already_lowercase_is_left_alone(): void
+    {
+        $result = $this->normalise(['connect' => ['protocol' => 'telnet']]);
+
+        $this->assertSame('telnet', $result['connect']['protocol']);
+    }
+
+    public function test_a_null_template_is_returned_untouched(): void
+    {
+        $this->assertNull($this->normaliser->normalise(null));
+    }
+
+    public function test_a_full_template_normalises_every_switch_it_carries(): void
+    {
+        $template = Yaml::parse(file_get_contents(__DIR__ . '/../../storage/templates/vt100.yml'));
+
+        $result = $this->normalise($template);
+
+        $this->assertSame('ssh', $result['connect']['protocol']);
+        $this->assertSame('off', $result['auth']['enable']);
+        $this->assertSame('off', $result['config']['paging']);
+        $this->assertSame('on', $result['options']['AnsiHost']);
+        $this->assertSame('on', $result['vt100']['hasSplashScreen']);
+        $this->assertSame('off', $result['vt100']['hasSplashScreenEnterKey']);
+        $this->assertSame('terminal length 0', $result['config']['pagingCmd']);
+    }
+}


### PR DESCRIPTION
… case at parse time

Template values were consumed raw at each point of use, so every consumer invented its own comparison and the comparisons disagreed. Symfony's YAML parser types `on`, `off`, `yes` and `no` as strings but types `true` and `false` as real booleans, so the same authoring mistake produced opposite outcomes: `enable: true` still turned enable mode on because the comparison was loose, while `paging: true` silently stopped disabling the pager because the comparison was strict. Nothing was logged either way, and the paging case surfaces as truncated config output at the pager.

TemplateNormaliser runs once in ConnectionParams, right after the YAML parse, and is the only place that has to know about the spellings:

* `enable`, `enableUsername`, `hpAnyKeyStatus`, `sshInteractive`, `paging`, `isMikrotik`, `AnsiHost`, `isNonInteractiveMode`, `hasSplashScreen` and `hasSplashScreenEnterKey` are settled on 'on' or 'off'. Booleans, `yes` / `no`, `true` / `false`, casing and stray whitespace all land on the same two values.
* `connect.protocol` is lowercased and trimmed, so `protocol: SSH` dispatches instead of falling through to the generic "template file could be invalid" exception. That exception now names the offending value.
* A value nobody recognises is left exactly as written and logged as a warning, so it keeps its current off-by-default behaviour rather than being guessed at. A value that had to be rewritten is logged at info.

Consumers now compare the one canonical form. Three of those comparisons were doing something other than what they looked like:

* `AnsiHost` and `isMikrotik` were compared against 'yes' while every other switch was compared against 'on'.
* `isNonInteractiveMode` was read as a bare truthy value in two places, so the string 'off' selected the non-interactive exec path.
* `enable` and `hasSplashScreen` were compared loosely on both protocols.

Part (c) of the Pro ticket, the `idletimeout` spelling, does not apply: Core does not dispatch the script protocol.