### PR TITLE
closes RCO-1297 Core parity: escape the telnet device prompt before i…

### DIFF
--- a/app/Http/Controllers/Connections/Telnet/Read.php
+++ b/app/Http/Controllers/Connections/Telnet/Read.php
@@ -15,6 +15,7 @@ class Read
     private $character;
     protected $data;
     private $prompt;
+    private $promptPattern;
 
     public function __construct($connectionObj)
     {
@@ -30,6 +31,7 @@ class Read
     public function readTo($prompt)
     {
         $this->prompt = $prompt;
+        $this->promptPattern = $this->buildPromptPattern((string) $prompt);
         $this->errorIfNoConnection();
 
         while (($this->character = fgetc($this->connection)) !== false) {
@@ -44,9 +46,52 @@ class Read
         return $this->readToPrompt(); // this will end while loop on a match
     }
 
+    /**
+     * Build the pattern that spots the prompt at the tail of the read buffer.
+     *
+     * The prompt is free text taken from the device record, and `/` is the delimiter
+     * here. A prompt such as `admin@sw1/config#` used to close the pattern early, so
+     * every preg_match() failed and the read ran until the socket died rather than
+     * matching. Escape the delimiter only, which is what the SSH path does for its own
+     * `~` delimiter, so prompts deliberately written as patterns keep working. If the
+     * escaped prompt still will not compile, match the prompt literally instead of
+     * leaving the caller with a pattern that can never match.
+     */
+    private function buildPromptPattern(string $prompt): string
+    {
+        $pattern = '/' . str_replace('/', '\/', $prompt) . '$/';
+
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $compiles = preg_match($pattern, '') !== false;
+        } finally {
+            restore_error_handler();
+        }
+
+        return $compiles ? $pattern : '/' . preg_quote($prompt, '/') . '$/';
+    }
+
+    /**
+     * A prompt written as plain text is the common case, and plain text is allowed to
+     * contain regex metacharacters: `[admin@MikroTik] /interface>` reads as a character
+     * class followed by a literal, which compiles happily and then never matches. Take
+     * the literal tail first so those prompts work as typed, and fall through to the
+     * pattern so prompts deliberately written as regex keep working too. An empty prompt
+     * matches on the pattern, as it always has.
+     */
+    private function promptMatched(): bool
+    {
+        if ($this->prompt !== '' && $this->prompt !== null && str_ends_with((string) $this->data, (string) $this->prompt)) {
+            return true;
+        }
+
+        return (bool) preg_match($this->promptPattern, (string) $this->data);
+    }
+
     private function readToPrompt()
     {
-        if (preg_match('/' . $this->prompt . '$/', $this->data)) {
+        if ($this->promptMatched()) {
             if ($this->cliDebugStatus) {
                 dump($this->data);
             }

--- a/tests/Unit/Connections/TelnetPromptPatternTest.php
+++ b/tests/Unit/Connections/TelnetPromptPatternTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\Connections;
+
+use App\Http\Controllers\Connections\Telnet\Read as TelnetRead;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The telnet read loop spots the device prompt with a regex delimited by `/`, and the
+ * prompt itself is free text from the device record. A prompt carrying the delimiter
+ * closed the pattern early, so preg_match() failed on every character and the loop ran
+ * until the socket died instead of matching.
+ *
+ * Read holds a live socket, so it is built without its constructor and driven through
+ * its prompt handling alone.
+ */
+class TelnetPromptPatternTest extends TestCase
+{
+    private function buildPattern(string $prompt): string
+    {
+        $reflection = new ReflectionClass(TelnetRead::class);
+        $read = $reflection->newInstanceWithoutConstructor();
+
+        return $reflection->getMethod('buildPromptPattern')->invoke($read, $prompt);
+    }
+
+    private function matchesPrompt(string $prompt, string $buffer): bool
+    {
+        $reflection = new ReflectionClass(TelnetRead::class);
+        $read = $reflection->newInstanceWithoutConstructor();
+
+        $reflection->getProperty('prompt')->setValue($read, $prompt);
+        $reflection->getProperty('promptPattern')->setValue($read, $this->buildPattern($prompt));
+        $reflection->getProperty('data')->setValue($read, $buffer);
+
+        return (bool) $reflection->getMethod('readToPrompt')->invoke($read);
+    }
+
+    public function test_prompt_containing_the_delimiter_still_matches(): void
+    {
+        $this->assertTrue($this->matchesPrompt('admin@sw1/config#', "show run\r\nadmin@sw1/config#"));
+    }
+
+    public function test_mikrotik_style_prompt_still_matches(): void
+    {
+        $prompt = '[admin@MikroTik] /interface>';
+
+        $this->assertTrue($this->matchesPrompt($prompt, "output\r\n[admin@MikroTik] /interface>"));
+    }
+
+    public function test_plain_prompt_still_matches(): void
+    {
+        $this->assertTrue($this->matchesPrompt('sw1#', "show run\r\nsw1#"));
+    }
+
+    public function test_prompt_must_appear_at_the_end_of_the_buffer(): void
+    {
+        $this->assertFalse($this->matchesPrompt('sw1#', "sw1#\r\nshow running-config\r\n"));
+    }
+
+    public function test_buffer_without_the_prompt_does_not_match(): void
+    {
+        $this->assertFalse($this->matchesPrompt('admin@sw1/config#', "show run\r\nsomething else"));
+    }
+
+    public function test_prompt_full_of_metacharacters_matches_as_typed(): void
+    {
+        $this->assertTrue($this->matchesPrompt('sw1(config)#', "show run\r\nsw1(config)#"));
+        $this->assertTrue($this->matchesPrompt('R1.core+#', "show run\r\nR1.core+#"));
+        $this->assertFalse($this->matchesPrompt('sw1(config)#', "show run\r\nsw2(config)#"));
+    }
+
+    public function test_empty_prompt_still_matches_anything(): void
+    {
+        $this->assertTrue($this->matchesPrompt('', "show run\r\n"));
+    }
+
+    public function test_regex_capable_prompts_are_preserved(): void
+    {
+        $this->assertTrue($this->matchesPrompt('sw1[>#]', "show run\r\nsw1#"));
+        $this->assertTrue($this->matchesPrompt('sw1[>#]', "show run\r\nsw1>"));
+        $this->assertFalse($this->matchesPrompt('sw1[>#]', "show run\r\nsw1$"));
+    }
+
+    public function test_prompt_that_cannot_compile_falls_back_to_a_literal_match(): void
+    {
+        $prompt = 'sw1(config';
+
+        $this->assertSame('/' . preg_quote($prompt, '/') . '$/', $this->buildPattern($prompt));
+        $this->assertTrue($this->matchesPrompt($prompt, "show run\r\nsw1(config"));
+    }
+
+    public function test_every_built_pattern_compiles(): void
+    {
+        $prompts = [
+            'sw1#',
+            'admin@sw1/config#',
+            '[admin@MikroTik] /interface>',
+            'sw1(config',
+            'sw1[>#',
+            'sw1*',
+            '\\',
+        ];
+
+        foreach ($prompts as $prompt) {
+            $this->assertNotFalse(
+                preg_match($this->buildPattern($prompt), ''),
+                'Pattern built for prompt [' . $prompt . '] does not compile.'
+            );
+        }
+    }
+}


### PR DESCRIPTION
…t is used as a regex

The telnet read loop interpolated the device prompt straight into a `/.../` pattern. A prompt carrying the delimiter, such as `admin@sw1/config#` or a MikroTik `[admin@MikroTik] /interface>`, closed the pattern early, so every preg_match() failed and the loop read until the socket died instead of matching. The SSH path already escapes its own `~` delimiter; telnet escaped nothing.

The prompt is now escaped once per read rather than rebuilt per character:

* `/` is escaped, matching what SSH does for `~`, so prompts deliberately written as patterns keep working.
* If the escaped prompt still will not compile, it falls back to a fully quoted literal instead of leaving a pattern that can never match.
* The buffer tail is compared literally first, so a plain prompt containing regex metacharacters (brackets, parentheses, dots) matches as typed. That case compiled fine before and simply never matched.

Anchoring is unchanged: telnet still anchors with `$` where SSH does not. That asymmetry, and the unconditional `pagingCmd` question attached to the ticket, are decisions for RCO-1294 and are deliberately left alone here.